### PR TITLE
Extend programming language dropdown option to include Golang

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "js-slang/src/scm-slang"]
+	path = js-slang/src/scm-slang
+	url = https://github.com/source-academy/scm-slang.git
+[submodule "js-slang/src/py-slang"]
+	path = js-slang/src/py-slang
+	url = https://github.com/source-academy/py-slang

--- a/frontend/src/commons/application/ApplicationTypes.ts
+++ b/frontend/src/commons/application/ApplicationTypes.ts
@@ -172,10 +172,8 @@ export const htmlLanguage: SALanguage = {
   supports: {}
 };
 
-// Hardcoded to 100 for now, otherwise we need to edit js-slang's Chapter enum
-const GO_CHAPTER = 100;
 export const goLanguage: SALanguage = {
-  chapter: GO_CHAPTER,
+  chapter: Chapter.GOLANG,
   variant: Variant.DEFAULT,
   displayName: 'Golang',
   mainLanguage: SupportedLanguage.GOLANG,
@@ -329,7 +327,14 @@ export const defaultPlayground: PlaygroundState = {
   languageConfig: defaultLanguageConfig
 };
 
-export const defaultEditorValue = '// Type your program in here!';
+export const defaultEditorValue = `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello World!")
+}
+`;
 
 /**
  * Create a default IWorkspaceState for 'resetting' a workspace.

--- a/frontend/src/commons/application/ApplicationTypes.ts
+++ b/frontend/src/commons/application/ApplicationTypes.ts
@@ -106,13 +106,15 @@ export enum StoriesRole {
 export enum SupportedLanguage {
   JAVASCRIPT = 'JavaScript',
   SCHEME = 'Scheme',
-  PYTHON = 'Python'
+  PYTHON = 'Python',
+  GOLANG = 'Golang'
 }
 
 export const SUPPORTED_LANGUAGES = [
   SupportedLanguage.JAVASCRIPT,
   SupportedLanguage.SCHEME,
-  SupportedLanguage.PYTHON
+  SupportedLanguage.PYTHON,
+  SupportedLanguage.GOLANG
 ];
 
 /**
@@ -167,6 +169,16 @@ export const htmlLanguage: SALanguage = {
   variant: Variant.DEFAULT,
   displayName: 'HTML',
   mainLanguage: SupportedLanguage.JAVASCRIPT,
+  supports: {}
+};
+
+// Hardcoded to 100 for now, otherwise we need to edit js-slang's Chapter enum
+const GO_CHAPTER = 100;
+export const goLanguage: SALanguage = {
+  chapter: GO_CHAPTER,
+  variant: Variant.DEFAULT,
+  displayName: 'Golang',
+  mainLanguage: SupportedLanguage.GOLANG,
   supports: {}
 };
 
@@ -262,7 +274,8 @@ export const ALL_LANGUAGES: readonly SALanguage[] = [
   fullTSLanguage,
   htmlLanguage,
   ...schemeLanguages,
-  ...pyLanguages
+  ...pyLanguages,
+  goLanguage
 ];
 // TODO: Remove this function once logic has been fully migrated
 export const getLanguageConfig = (

--- a/frontend/src/commons/controlBar/ControlBarChapterSelect.tsx
+++ b/frontend/src/commons/controlBar/ControlBarChapterSelect.tsx
@@ -38,7 +38,6 @@ const chapterListRenderer: ItemListRenderer<SALanguage> = ({
   items
 }) => {
   const defaultChoices = items.filter(({ variant }) => variant === Variant.DEFAULT);
-  console.log(defaultChoices)
   const variantChoices = items.filter(({ variant }) => variant !== Variant.DEFAULT);
 
   return (

--- a/frontend/src/commons/controlBar/ControlBarChapterSelect.tsx
+++ b/frontend/src/commons/controlBar/ControlBarChapterSelect.tsx
@@ -8,12 +8,13 @@ import React from 'react';
 import {
   fullJSLanguage,
   fullTSLanguage,
+  goLanguage,
   htmlLanguage,
   pyLanguages,
   SALanguage,
   schemeLanguages,
   sourceLanguages,
-  styliseSublanguage
+  styliseSublanguage,
 } from '../application/ApplicationTypes';
 import Constants from '../utils/Constants';
 import { useTypedSelector } from '../utils/Hooks';
@@ -37,6 +38,7 @@ const chapterListRenderer: ItemListRenderer<SALanguage> = ({
   items
 }) => {
   const defaultChoices = items.filter(({ variant }) => variant === Variant.DEFAULT);
+  console.log(defaultChoices)
   const variantChoices = items.filter(({ variant }) => variant !== Variant.DEFAULT);
 
   return (
@@ -85,7 +87,7 @@ export const ControlBarChapterSelect: React.FC<ControlBarChapterSelectProps> = (
     // Full JS/TS version uses eval(), which is a huge security risk, so we only enable
     // for public deployments. HTML, while sandboxed, is treated the same way to be safe.
     // See https://github.com/source-academy/frontend/pull/2460#issuecomment-1528759912
-    ...(Constants.playgroundOnly ? [fullJSLanguage, fullTSLanguage, htmlLanguage] : []),
+    ...(Constants.playgroundOnly ? [fullJSLanguage, fullTSLanguage, htmlLanguage, goLanguage] : []),
     ...schemeLanguages,
     ...pyLanguages
   ];

--- a/frontend/src/commons/editor/Editor.tsx
+++ b/frontend/src/commons/editor/Editor.tsx
@@ -2,6 +2,7 @@
 import { Ace, createEditSession, require as acequire } from 'ace-builds';
 import 'ace-builds/src-noconflict/ext-language_tools';
 import 'ace-builds/src-noconflict/ext-searchbox';
+import 'ace-builds/src-noconflict/mode-golang';
 import 'js-slang/dist/editors/ace/theme/source';
 
 import { Chapter, Variant } from 'js-slang/dist/types';
@@ -575,7 +576,7 @@ const Editor: React.FC<EditorProps> = (props: EditorProps) => {
   const [sessions, setSessions] = React.useState<Record<string, Ace.EditSession>>({});
 
   // Create new edit session.
-  const defaultMode = acequire('ace/mode/javascript').Mode();
+  const defaultMode = acequire('ace/mode/golang').Mode();
   const defaultEditSession = createEditSession(props.editorValue, defaultMode);
 
   // Initialise edit session if file path has not been seen before.

--- a/frontend/src/commons/navigationBar/subcomponents/NavigationBarLangSelectButton.tsx
+++ b/frontend/src/commons/navigationBar/subcomponents/NavigationBarLangSelectButton.tsx
@@ -4,7 +4,6 @@ import { useDispatch } from 'react-redux';
 import {
   getLanguageConfig,
   goLanguage,
-  // goLanguages,
   pyLanguages,
   SALanguage,
   schemeLanguages,

--- a/frontend/src/commons/navigationBar/subcomponents/NavigationBarLangSelectButton.tsx
+++ b/frontend/src/commons/navigationBar/subcomponents/NavigationBarLangSelectButton.tsx
@@ -28,7 +28,6 @@ const defaultSublanguages: {
 
 const NavigationBarLangSelectButton = () => {
   const [isOpen, setIsOpen] = useState(false);
-  // TODO: how to access languageConfig to update mainLanguage to be Golang?
   const lang = useTypedSelector(store => store.playground.languageConfig.mainLanguage);
   const dispatch = useDispatch();
   const selectLang = (language: SupportedLanguage) => {

--- a/frontend/src/commons/navigationBar/subcomponents/NavigationBarLangSelectButton.tsx
+++ b/frontend/src/commons/navigationBar/subcomponents/NavigationBarLangSelectButton.tsx
@@ -3,6 +3,8 @@ import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import {
   getLanguageConfig,
+  goLanguage,
+  // goLanguages,
   pyLanguages,
   SALanguage,
   schemeLanguages,
@@ -21,11 +23,13 @@ const defaultSublanguages: {
 } = {
   [SupportedLanguage.JAVASCRIPT]: sourceLanguages[0],
   [SupportedLanguage.PYTHON]: pyLanguages[0],
-  [SupportedLanguage.SCHEME]: schemeLanguages[0]
+  [SupportedLanguage.SCHEME]: schemeLanguages[0],
+  [SupportedLanguage.GOLANG]: goLanguage
 };
 
 const NavigationBarLangSelectButton = () => {
   const [isOpen, setIsOpen] = useState(false);
+  // TODO: how to access languageConfig to update mainLanguage to be Golang?
   const lang = useTypedSelector(store => store.playground.languageConfig.mainLanguage);
   const dispatch = useDispatch();
   const selectLang = (language: SupportedLanguage) => {

--- a/frontend/src/commons/utils/AceHelper.ts
+++ b/frontend/src/commons/utils/AceHelper.ts
@@ -50,6 +50,8 @@ export const getModeString = (chapter: Chapter, variant: Variant, library: strin
     case Chapter.SCHEME_4:
     case Chapter.FULL_SCHEME:
       return 'scheme';
+    case Chapter.GOLANG:
+      return 'golang'
     default:
       return `source${chapter}${variant}${library}`;
   }

--- a/frontend/src/commons/utils/Constants.ts
+++ b/frontend/src/commons/utils/Constants.ts
@@ -1,4 +1,4 @@
-import { Chapter, Variant } from 'js-slang/dist/types';
+import { Variant } from 'js-slang/dist/types';
 
 import { AuthProviderType } from './AuthHelper';
 
@@ -21,7 +21,8 @@ const storiesBackendUrl = process.env.REACT_APP_STORIES_BACKEND_URL;
 const cadetLoggerUrl = isTest ? undefined : process.env.REACT_APP_CADET_LOGGER;
 const cadetLoggerInterval = parseInt(process.env.REACT_APP_CADET_LOGGER_INTERVAL || '10000', 10);
 const useBackend = !isTest && isTrue(process.env.REACT_APP_USE_BACKEND);
-const defaultSourceChapter = Chapter.SOURCE_4;
+// TODO: Hardcoded to use 100. Otherwise, need edit js-slang's Chapter enum
+const defaultSourceChapter = 100;
 const defaultSourceVariant = Variant.DEFAULT;
 const defaultQuestionId = 0;
 const maxBrowseIndex = 50;

--- a/frontend/src/commons/utils/Constants.ts
+++ b/frontend/src/commons/utils/Constants.ts
@@ -1,4 +1,4 @@
-import { Variant } from 'js-slang/dist/types';
+import { Chapter, Variant } from 'js-slang/dist/types';
 
 import { AuthProviderType } from './AuthHelper';
 
@@ -21,8 +21,7 @@ const storiesBackendUrl = process.env.REACT_APP_STORIES_BACKEND_URL;
 const cadetLoggerUrl = isTest ? undefined : process.env.REACT_APP_CADET_LOGGER;
 const cadetLoggerInterval = parseInt(process.env.REACT_APP_CADET_LOGGER_INTERVAL || '10000', 10);
 const useBackend = !isTest && isTrue(process.env.REACT_APP_USE_BACKEND);
-// TODO: Hardcoded to use 100. Otherwise, need edit js-slang's Chapter enum
-const defaultSourceChapter = 100;
+const defaultSourceChapter = Chapter.GOLANG;
 const defaultSourceVariant = Variant.DEFAULT;
 const defaultQuestionId = 0;
 const maxBrowseIndex = 50;

--- a/js-slang/.gitmodules
+++ b/js-slang/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "src/scm-slang"]
-	path = src/scm-slang
-	url = https://github.com/source-academy/scm-slang.git
-[submodule "src/py-slang"]
-	path = src/py-slang
-	url = https://github.com/source-academy/py-slang

--- a/js-slang/package.json
+++ b/js-slang/package.json
@@ -63,8 +63,7 @@
     "autocomplete": "node ./scripts/updateAutocompleteDocs.js",
     "build_sicp_package": "./scripts/build_sicp_package.sh",
     "publish_sicp_package": "./scripts/publish_sicp_package.sh",
-    "benchmark": "jest --runInBand --testPathPattern='.*benchmark.*' --testPathIgnorePatterns='/dist/'",
-    "prepare": "husky install"
+    "benchmark": "jest --runInBand --testPathPattern='.*benchmark.*' --testPathIgnorePatterns='/dist/'"
   },
   "devDependencies": {
     "@types/jest": "^29.0.0",

--- a/js-slang/scripts/jsdoc.sh
+++ b/js-slang/scripts/jsdoc.sh
@@ -13,11 +13,8 @@ main() {
 	prepare
     elif [ "$1" == "clean" ]; then
 	clean
-    elif [[ "$(git rev-parse --show-toplevel 2> /dev/null)" -ef "$PWD" ]]; then
-        run
     else
-        echo "Please run this command from the git root directory."
-        false  # exit 1
+	run
     fi
 }
 

--- a/js-slang/src/types.ts
+++ b/js-slang/src/types.ts
@@ -80,7 +80,8 @@ export enum Chapter {
   SCHEME_3 = -11,
   SCHEME_4 = -12,
   FULL_SCHEME = -13,
-  LIBRARY_PARSER = 100
+  GOLANG = -14,
+  LIBRARY_PARSER = 100,
 }
 
 export enum Variant {


### PR DESCRIPTION
This pull request is purely a UI change - extending the dropdown UI to include Golang. The "backend" interpreter to run the code is still JavaScript. We can discuss whether to change the "backend" interpreter to another PR or include together with this. I have not looked into the backend interpreter yet. 

The default language in the Playground is now set to be Golang.

UI changes made:
<img width="1440" alt="dropdown-ui-1" src="https://github.com/xlzior/goats/assets/46375597/dc87eac8-fd62-4eb5-a3b9-d3e102a979cc">
<img width="1437" alt="dropdown-ui-2" src="https://github.com/xlzior/goats/assets/46375597/95fd5baf-139b-45e9-8133-c104812d7b3d">
