### PR TITLE
Set up autoformatter

### DIFF
--- a/go-slang/README.md
+++ b/go-slang/README.md
@@ -26,6 +26,13 @@ yarn build
 ```
 The built JavaScript files are located at the `dist` directory.
 
+
+To format using Biome:
+
+```
+yarn format
+```
+
 ## Using your go-slang in your local js-slang
 
 First, build and link your local go-slang:

--- a/go-slang/__tests__/runner.test.ts
+++ b/go-slang/__tests__/runner.test.ts
@@ -1,22 +1,29 @@
 import { GolangRunner } from "../src";
 
-let golangRunner: GolangRunner
+let golangRunner: GolangRunner;
 
 beforeEach(() => {
-  golangRunner = new GolangRunner()
+  golangRunner = new GolangRunner();
 });
 
-describe('Golang runner for evaluating binary expressions', () => {
-
+describe("Golang runner for evaluating binary expressions", () => {
   const binaryExprTestCases = [
-    { program: "package main\n\nimport \"fmt\"\n\nfunc main() {\n\t1 + 2\n}", expected: 3 },
-    { program: "package main\n\nimport \"fmt\"\n\nfunc main() {\n\t10 * 2 / 5\n}", expected: 4.0 },
+    {
+      program: 'package main\n\nimport "fmt"\n\nfunc main() {\n\t1 + 2\n}',
+      expected: 3,
+    },
+    {
+      program: 'package main\n\nimport "fmt"\n\nfunc main() {\n\t10 * 2 / 5\n}',
+      expected: 4.0,
+    },
     // Add more test cases here
   ];
-  
-  test.each(binaryExprTestCases)('evaluate binary expr: %s', async ({ program, expected }) => {
-    const actual = await golangRunner.execute(program);
-    expect(actual).toEqual(expected);
-  });
 
-})
+  test.each(binaryExprTestCases)(
+    "evaluate binary expr: %s",
+    async ({ program, expected }) => {
+      const actual = await golangRunner.execute(program);
+      expect(actual).toEqual(expected);
+    }
+  );
+});

--- a/go-slang/biome.json
+++ b/go-slang/biome.json
@@ -3,6 +3,9 @@
   "organizeImports": {
     "enabled": true
   },
+  "formatter": {
+    "indentStyle": "space"
+  },
   "linter": {
     "enabled": false,
     "rules": {

--- a/go-slang/biome.json
+++ b/go-slang/biome.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.6.0/schema.json",
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": false,
+    "rules": {
+      "recommended": true
+    }
+  }
+}

--- a/go-slang/package.json
+++ b/go-slang/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "scripts": {
     "test": "jest",
-    "build": "tsc"
+    "build": "tsc",
+    "format": "biome format --write ./src"
   },
   "devDependencies": {
     "@biomejs/biome": "1.6.0",

--- a/go-slang/package.json
+++ b/go-slang/package.json
@@ -8,6 +8,7 @@
     "build": "tsc"
   },
   "devDependencies": {
+    "@biomejs/biome": "1.6.0",
     "@types/jest": "^29.5.12",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",

--- a/go-slang/src/compiler/index.ts
+++ b/go-slang/src/compiler/index.ts
@@ -1,37 +1,32 @@
-import {
-  BasicLiteral,
-  BinaryExpr,
-}
-  from "../types"
+import { BasicLiteral, BinaryExpr } from "../types";
 
 export class GolangCompiler {
-  private wc: number
-  private instrs: Array<any>
-  private compile_comp: any
+  private wc: number;
+  private instrs: Array<any>;
+  private compile_comp: any;
 
   constructor() {
-    this.wc = 0
-    this.instrs = []
+    this.wc = 0;
+    this.instrs = [];
     this.compile_comp = {
       BasicLit: (comp: BasicLiteral) => {
-        this.instrs[this.wc++] = { tag: "LDC", val: Number(comp.Value) }
+        this.instrs[this.wc++] = { tag: "LDC", val: Number(comp.Value) };
       },
       BinaryExpr: (comp: BinaryExpr) => {
-        this.compile(comp.X)
-        this.compile(comp.Y)
-        this.instrs[this.wc++] = { tag: 'BINOP', sym: comp.Op }
+        this.compile(comp.X);
+        this.compile(comp.Y);
+        this.instrs[this.wc++] = { tag: "BINOP", sym: comp.Op };
       },
-    }
+    };
   }
 
   private compile(comp: any) {
-    this.compile_comp[comp._type](comp)
-    this.instrs[this.wc] = { tag: 'DONE' }
-    return this.instrs
+    this.compile_comp[comp._type](comp);
+    this.instrs[this.wc] = { tag: "DONE" };
+    return this.instrs;
   }
 
   compile_program(ast: any) {
-    return this.compile(ast)
+    return this.compile(ast);
   }
-
 }

--- a/go-slang/src/index.ts
+++ b/go-slang/src/index.ts
@@ -1,28 +1,27 @@
-import { GolangParser } from "./parser"
-import { GolangCompiler } from "./compiler"
-import { GolangVM } from "./vm"
+import { GolangParser } from "./parser";
+import { GolangCompiler } from "./compiler";
+import { GolangVM } from "./vm";
 
 // Facade class that contains parser, compiler and vm / main entry point
 export class GolangRunner {
-
-  private parser: GolangParser
-  private compiler: GolangCompiler
-  private vm: GolangVM
+  private parser: GolangParser;
+  private compiler: GolangCompiler;
+  private vm: GolangVM;
 
   constructor() {
-    this.parser = new GolangParser()
-    this.compiler = new GolangCompiler()
-    this.vm = new GolangVM()
+    this.parser = new GolangParser();
+    this.compiler = new GolangCompiler();
+    this.vm = new GolangVM();
   }
 
   async execute(program: string) {
     try {
-      const ast = await this.parser.parse(program)
-      const instr_set = this.compiler.compile_program(ast)
-      const result = this.vm.run(instr_set)
-      return result
+      const ast = await this.parser.parse(program);
+      const instr_set = this.compiler.compile_program(ast);
+      const result = this.vm.run(instr_set);
+      return result;
     } catch (e: any) {
-      console.error(e)
+      console.error(e);
     }
   }
 }

--- a/go-slang/src/parser/index.ts
+++ b/go-slang/src/parser/index.ts
@@ -1,34 +1,30 @@
-const API_ENDPOINT = 'http://localhost:8080/parse'
+const API_ENDPOINT = "http://localhost:8080/parse";
 
 export class GolangParser {
-
   async parse(programString: string) {
-
     const requestBody = {
-      program: programString
-    }
+      program: programString,
+    };
 
     const fetchOptions = {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
       body: JSON.stringify(requestBody),
-    }
+    };
 
     try {
-      const response = await fetch(API_ENDPOINT, fetchOptions)
-      const data = await response.json()
+      const response = await fetch(API_ENDPOINT, fetchOptions);
+      const data = await response.json();
       // console.log(JSON.stringify(data, null, 2))
       // return data.ast
 
-      const binaryExprAST = data.ast.Decls[1].Body.List[0].X
-      return binaryExprAST
-      
+      const binaryExprAST = data.ast.Decls[1].Body.List[0].X;
+      return binaryExprAST;
     } catch (e) {
-      console.error(e)
-      return null
+      console.error(e);
+      return null;
     }
-    
   }
 }

--- a/go-slang/src/types.ts
+++ b/go-slang/src/types.ts
@@ -14,7 +14,7 @@ export enum NodeType {
   IF_STMT = "IfStmt",
   RETURN_STMT = "ReturnStmt",
   EXPR_STMT = "ExprStmt",
-  BRANCH_STMT = "BranchStmt"
+  BRANCH_STMT = "BranchStmt",
 }
 
 export enum Op {
@@ -33,110 +33,110 @@ export enum Op {
 // FILE - ROOT AST NODE
 // ========================
 export interface File {
-  _type: NodeType.FILE
-  Decls: Decl[]
-  Name: Ident // package name
+  _type: NodeType.FILE;
+  Decls: Decl[];
+  Name: Ident; // package name
 }
 
 // ========================
 // DECLARATIONS
 // ========================
 
-export interface Decl { }
+export interface Decl {}
 
 interface Field {
-  Names: Ident[] // field/method parameter names
-  _type: Expr // parameter types
+  Names: Ident[]; // field/method parameter names
+  _type: Expr; // parameter types
 }
 
 interface FieldList {
-  List: Field[]
+  List: Field[];
 }
 
 interface FuncType {
-  Params: FieldList  // function parameters 
-  Results: FieldList // return _type
+  Params: FieldList; // function parameters
+  Results: FieldList; // return _type
 }
 
 export interface FuncDecl extends Decl {
-  _type: NodeType.FUNC_DECL
-  Name: Ident,
-  Body: BlockStmt,
-  Type: FuncType
+  _type: NodeType.FUNC_DECL;
+  Name: Ident;
+  Body: BlockStmt;
+  Type: FuncType;
 }
 
 // ========================
 // EXPRESSIONS
 // ========================
 
-export interface Expr { }
+export interface Expr {}
 
 export interface BasicLiteral extends Expr {
-  _type: NodeType.BASIC_LITERAL
+  _type: NodeType.BASIC_LITERAL;
   Kind: string;
-  Value: number | string
+  Value: number | string;
 }
 
 export interface BinaryExpr extends Expr {
-  _type: NodeType.BINARY_EXPR
+  _type: NodeType.BINARY_EXPR;
   Op: Op;
   X: Expr;
   Y: Expr;
 }
 
 export interface Ident extends Expr {
-  _type: NodeType.IDENT
+  _type: NodeType.IDENT;
   Name: string;
 }
 
 export interface CallExpr extends Expr {
-  _type: NodeType.CALL_EXPR,
-  Args: Expr[],
-  Fun: Ident,
+  _type: NodeType.CALL_EXPR;
+  Args: Expr[];
+  Fun: Ident;
 }
-
 
 // ========================
 // STATEMENTS
 // ========================
 
-export interface Stmt { }
+export interface Stmt {}
 
 export interface AssignStmt extends Stmt {
-  _type: NodeType.ASSIGN_STMT
-  Lhs: Ident[],
-  Rhs: Expr[]
+  _type: NodeType.ASSIGN_STMT;
+  Lhs: Ident[];
+  Rhs: Expr[];
 }
 
 export interface BlockStmt extends Stmt {
-  _type: NodeType.BLOCK_STMT
-  List: Stmt[]
+  _type: NodeType.BLOCK_STMT;
+  List: Stmt[];
 }
 
 export interface IfStmt extends Stmt {
-  _type: NodeType.IF_STMT
-  Cond: Expr,
-  Body: BlockStmt,
-  Else: BlockStmt | IfStmt
+  _type: NodeType.IF_STMT;
+  Cond: Expr;
+  Body: BlockStmt;
+  Else: BlockStmt | IfStmt;
 }
 
 export interface ForStmt extends Stmt {
-  _type: NodeType.FOR_STMT
-  Body: BlockStmt,
-  Cond: Expr
+  _type: NodeType.FOR_STMT;
+  Body: BlockStmt;
+  Cond: Expr;
 }
 
-export interface ExprStmt extends Stmt { // calling a function
-  _type: NodeType.EXPR_STMT
-  Expr: CallExpr
+export interface ExprStmt extends Stmt {
+  // calling a function
+  _type: NodeType.EXPR_STMT;
+  Expr: CallExpr;
 }
 
 export interface ReturnStmt extends Stmt {
-  _type: NodeType.RETURN_STMT
-  Results: Expr[]
+  _type: NodeType.RETURN_STMT;
+  Results: Expr[];
 }
 
 export interface BranchStmt extends Stmt {
-  _type: NodeType.BRANCH_STMT
+  _type: NodeType.BRANCH_STMT;
   Token: string; // keyword token (break, continue)
 }

--- a/go-slang/src/vm/index.ts
+++ b/go-slang/src/vm/index.ts
@@ -1,59 +1,58 @@
 function peek(stack: Array<any>) {
-  if (stack.length === 0) throw new Error("Stack is empty!")
+  if (stack.length === 0) throw new Error("Stack is empty!");
   return stack[stack.length - 1];
 }
 
 const binop_microcode: any = {
-  '+': (x: any, y: any) => x + y,
-  '*': (x: number, y: number) => x * y,
-  '-': (x: number, y: number) => x - y,
-  '/': (x: number, y: number) => x / y,
-  '%': (x: number, y: number) => x % y,
-  '<': (x: number, y: number) => x < y,
-  '<=': (x: number, y: number) => x <= y,
-  '>=': (x: number, y: number) => x >= y,
-  '>': (x: number, y: number) => x > y,
-  '===': (x: number, y: number) => x === y,
-  '!==': (x: number, y: number) => x !== y
-}
+  "+": (x: any, y: any) => x + y,
+  "*": (x: number, y: number) => x * y,
+  "-": (x: number, y: number) => x - y,
+  "/": (x: number, y: number) => x / y,
+  "%": (x: number, y: number) => x % y,
+  "<": (x: number, y: number) => x < y,
+  "<=": (x: number, y: number) => x <= y,
+  ">=": (x: number, y: number) => x >= y,
+  ">": (x: number, y: number) => x > y,
+  "===": (x: number, y: number) => x === y,
+  "!==": (x: number, y: number) => x !== y,
+};
 
-const apply_binop = (op: string, v2: number, v1: number) => binop_microcode[op](v1, v2)
+const apply_binop = (op: string, v2: number, v1: number) =>
+  binop_microcode[op](v1, v2);
 
 export class GolangVM {
-  private OS: Array<any>
-  private PC: number
-  private E: Array<any>
-  private RTS: Array<any>
-  private microcode: any
+  private OS: Array<any>;
+  private PC: number;
+  private E: Array<any>;
+  private RTS: Array<any>;
+  private microcode: any;
 
   constructor() {
-    this.OS = []
-    this.PC = 0
-    this.E = []
-    this.RTS = []
+    this.OS = [];
+    this.PC = 0;
+    this.E = [];
+    this.RTS = [];
     this.microcode = {
-      LDC:
-        (instr: any)=> {
-          this.PC++
-          this.OS.push(instr.val)
-        },
-      BINOP:
-        (instr: any) => {
-          this.PC++
-          this.OS.push(apply_binop(instr.sym, this.OS.pop(), this.OS.pop()))
-        },
-    }
+      LDC: (instr: any) => {
+        this.PC++;
+        this.OS.push(instr.val);
+      },
+      BINOP: (instr: any) => {
+        this.PC++;
+        this.OS.push(apply_binop(instr.sym, this.OS.pop(), this.OS.pop()));
+      },
+    };
   }
 
   run(instrs: any) {
-    while (!(instrs[this.PC].tag === 'DONE')) {
-      const instr = instrs[this.PC]
-      this.microcode[instr.tag](instr)
+    while (!(instrs[this.PC].tag === "DONE")) {
+      const instr = instrs[this.PC];
+      this.microcode[instr.tag](instr);
     }
     // TODO: hotfix to solve tsc compile errors due to unused variables
     // will be fixed once we use them anyway
     this.E;
     this.RTS;
-    return peek(this.OS)
+    return peek(this.OS);
   }
 }

--- a/go-slang/yarn.lock
+++ b/go-slang/yarn.lock
@@ -297,6 +297,60 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@biomejs/biome@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@biomejs/biome/-/biome-1.6.0.tgz#b0f3bcc93451a7de74288af30f62f80aa74b1283"
+  integrity sha512-hvP8K1+CV8qc9eNdXtPwzScVxFSHB448CPKSqX6+8IW8G7bbhBVKGC80BowExJN5+vu+kzsj4xkWa780MAOlJw==
+  optionalDependencies:
+    "@biomejs/cli-darwin-arm64" "1.6.0"
+    "@biomejs/cli-darwin-x64" "1.6.0"
+    "@biomejs/cli-linux-arm64" "1.6.0"
+    "@biomejs/cli-linux-arm64-musl" "1.6.0"
+    "@biomejs/cli-linux-x64" "1.6.0"
+    "@biomejs/cli-linux-x64-musl" "1.6.0"
+    "@biomejs/cli-win32-arm64" "1.6.0"
+    "@biomejs/cli-win32-x64" "1.6.0"
+
+"@biomejs/cli-darwin-arm64@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.6.0.tgz#60f3620ccb2aac618afd9cd119291afa69d4aabf"
+  integrity sha512-K1Fjqye5pt+Ua+seC7V/2bFjfnqOaEOcQbBQSiiefB/VPNOb6lA5NFIfJ1PskTA3JrMXE1k7iqKQn56qrKFS6A==
+
+"@biomejs/cli-darwin-x64@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.6.0.tgz#dd3a0d66ff22f800bb13df33cb4dacf191eefe78"
+  integrity sha512-CjEALu6vN9RbcfhaBDoj481mesUIsUjxgQn+/kiMCea+Paypqslhez1I7OwRBJnkzz+Pa+PXdABd7S30eyy6+Q==
+
+"@biomejs/cli-linux-arm64-musl@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.6.0.tgz#cf2b171757f4f2062076ca323f2f23c1753208e9"
+  integrity sha512-prww6AUuJ+IO/GziN3WjtGM/DNOVuPFxqWrK97wKTZygEDdA+o1qHUN2HeCkSyk084xnzbMSbls5xscAKAn43A==
+
+"@biomejs/cli-linux-arm64@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.6.0.tgz#a7f2761d8566b2fdc78e09fc0d85cf1fccce602e"
+  integrity sha512-32LVrC7dAgQT39YZ0ieO/VzzpAflozs9mW5K0oKNef7S4ocCdk89E98eXApxOdei0JTf3vfseDCl1AUIp6MwJw==
+
+"@biomejs/cli-linux-x64-musl@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.6.0.tgz#95e17927d498af868cca32e3be79132ddeb3036f"
+  integrity sha512-NwitWeUKCy8G/rr+rgHPYirnrsOjJEJBWODdaRzweeFNcJjvO6de6AmNdSJzsewzLEaxjOWyoXU03MdzbGz/6Q==
+
+"@biomejs/cli-linux-x64@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-linux-x64/-/cli-linux-x64-1.6.0.tgz#bcab0e71981a5601d85ea3ef09454b262764b776"
+  integrity sha512-b6mWu9Cu4w5B3K46wq9SlxKEZEEL6II/6HFNAuZ4YL8mOeQ0FTMU+wNMJFKkmkSE2zvim3xwW3PknmbLKbe3Mg==
+
+"@biomejs/cli-win32-arm64@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.6.0.tgz#af94814be3c15ae4d201c01708a4ef79378cad36"
+  integrity sha512-DlNOL6mG+76iZS1gL/UiuMme7jnt+auzo2+u0aUq6UXYsb75juchwlnVLy2UV5CQjVBRB8+RM+KVoXRZ8NlBjQ==
+
+"@biomejs/cli-win32-x64@1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@biomejs/cli-win32-x64/-/cli-win32-x64-1.6.0.tgz#a90b549170864eff030a6b7e395f48ead5193170"
+  integrity sha512-sXBcXIOGuG8/XcHqmnkhLIs0oy6Dp+TkH4Alr4WH/P8mNsp5GcStI/ZwbEiEoxA0P3Fi+oUppQ6srxaY2rSCHg==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
# package.json script

```
yarn format
```

# VSCode Extension

Refer to [Biome documentation](https://biomejs.dev/guides/integrate-in-editor/#vs-code) on how to set up the VSCode extension

<img width="668" alt="image" src="https://github.com/xlzior/goats/assets/30801910/35b1b90b-39e4-4f80-a50b-bb5f45a0aec6">

If you get this error, it happens because biome is installed in a subdirectory, not the root directory. For the extension to work, the go-slang folder must be the topmost directory in the window.

<img width="470" alt="image" src="https://github.com/xlzior/goats/assets/30801910/1c5e9f28-61aa-46f9-a682-67ea30b291e2">
