### PR TITLE
Propagate logs from go-slang to frontend

### DIFF
--- a/go-slang/__tests__/runner.test.ts
+++ b/go-slang/__tests__/runner.test.ts
@@ -7,7 +7,7 @@ beforeEach(() => {
 });
 
 describe("Golang runner for evaluating binary expressions", () => {
-  const binaryExprTestCases = [
+  const singleLinebinaryExprTestCases = [
     {
       program: 'package main\n\nimport "fmt"\n\nfunc main() {\n\t1 + 2\n}',
       expected: 3,
@@ -19,11 +19,19 @@ describe("Golang runner for evaluating binary expressions", () => {
     // Add more test cases here
   ];
 
-  test.each(binaryExprTestCases)(
-    "evaluate binary expr: %s",
+  test.each(singleLinebinaryExprTestCases)(
+    "evaluate program with a single line of binary expr: %s",
     async ({ program, expected }) => {
       const actual = await golangRunner.execute(program);
-      expect(actual).toEqual(expected);
+      expect(actual.value).toEqual(expected);
     }
   );
+
+  test('evaluate program with multiple lines of binary expr should return the result of the last evaluated expr', async () => {
+    const program = 'package main\n\nimport "fmt"\n\nfunc main() {\n\t10 * 2 / 5\n33 - 13\n10 * 7 - 5\n}'
+    const actual = await golangRunner.execute(program)
+    const expected = 65
+    expect(actual.value).toEqual(expected);
+  })
+
 });

--- a/go-slang/src/compiler/index.ts
+++ b/go-slang/src/compiler/index.ts
@@ -1,32 +1,57 @@
-import { BasicLiteral, BinaryExpr } from "../types";
+import {
+  File,
+  BasicLit,
+  BinaryExpr,
+  BlockStmt,
+  ExprStmt,
+  FuncDecl,
+} from "../types";
 
 export class GolangCompiler {
   private wc: number;
   private instrs: Array<any>;
-  private compile_comp: any;
+  private compile_ast: any;
 
   constructor() {
     this.wc = 0;
     this.instrs = [];
-    this.compile_comp = {
-      BasicLit: (comp: BasicLiteral) => {
-        this.instrs[this.wc++] = { tag: "LDC", val: Number(comp.Value) };
+    this.compile_ast = {
+      BasicLit: (astNode: BasicLit) => {
+        this.instrs[this.wc++] = { tag: "LDC", val: Number(astNode.Value) };
       },
-      BinaryExpr: (comp: BinaryExpr) => {
-        this.compile(comp.X);
-        this.compile(comp.Y);
-        this.instrs[this.wc++] = { tag: "BINOP", sym: comp.Op };
+      BinaryExpr: (astNode: BinaryExpr) => {
+        this.compile(astNode.X);
+        this.compile(astNode.Y);
+        this.instrs[this.wc++] = { tag: "BINOP", sym: astNode.Op };
+      },
+      // TODO: to compile other properties of FuncDecl in a future PR that handles function constructs
+      FuncDecl: (astNode: FuncDecl) => {
+        this.compile(astNode.Body);
+      }, 
+      // TODO: to handle block scope of variables in a future PR that handles block construct
+      BlockStmt: (astNode: BlockStmt) => {
+        const stmts = astNode.List;
+        stmts.forEach(stmt => this.compile(stmt))
+      },
+      ExprStmt: (astNode: ExprStmt) => {
+        this.compile(astNode.X);
       },
     };
   }
 
-  private compile(comp: any) {
-    this.compile_comp[comp._type](comp);
+  private compile(astNode: any) {
+    // Currently ignores AST nodes that are unimplemented
+    if (this.compile_ast[astNode._type] !== undefined) {
+      this.compile_ast[astNode._type](astNode);
+    }
     this.instrs[this.wc] = { tag: "DONE" };
     return this.instrs;
   }
 
-  compile_program(ast: any) {
-    return this.compile(ast);
+  // Currently, it assumes there is only one function, which is main()
+  // TODO: We need check which function is main and then return the PC that starts from main? this can be discussed
+  compile_program(rootAstNode: File) {
+    rootAstNode.Decls.forEach(node => this.compile(node))
+    return this.instrs;
   }
 }

--- a/go-slang/src/index.ts
+++ b/go-slang/src/index.ts
@@ -35,6 +35,7 @@ export class GolangRunner {
       const result = this.vm.run(instr_set);
       return {
         value: result,
+        logs: ["TODO"],
       };
     } catch (e: any) {
       return {

--- a/go-slang/src/parser/index.ts
+++ b/go-slang/src/parser/index.ts
@@ -1,7 +1,9 @@
+import { ParserResult } from "../types";
+
 const API_ENDPOINT = "http://localhost:8080/parse";
 
 export class GolangParser {
-  async parse(programString: string) {
+  async parse(programString: string): Promise<ParserResult> {
     const requestBody = {
       program: programString,
     };
@@ -16,15 +18,11 @@ export class GolangParser {
 
     try {
       const response = await fetch(API_ENDPOINT, fetchOptions);
-      const data = await response.json();
-      // console.log(JSON.stringify(data, null, 2))
-      // return data.ast
-
-      const binaryExprAST = data.ast.Decls[1].Body.List[0].X;
-      return binaryExprAST;
+      const data: ParserResult = await response.json();
+      return data;
     } catch (e) {
       console.error(e);
-      return null;
+      return { error: "An error occurred while parsing" };
     }
   }
 }

--- a/go-slang/src/types.ts
+++ b/go-slang/src/types.ts
@@ -1,3 +1,13 @@
+export interface ParserResult {
+  ast?: File;
+  error?: string;
+}
+
+export interface RunnerResult {
+  value?: string;
+  error?: string;
+}
+
 // ========================
 // CONSTANTS
 // ========================
@@ -5,7 +15,7 @@ export enum NodeType {
   FILE = "File",
   FUNC_DECL = "FuncDecl",
   IDENT = "Ident",
-  BASIC_LITERAL = "BasicLiteral",
+  BASIC_LIT = "BasicLit",
   BINARY_EXPR = "BinaryExpr",
   CALL_EXPR = "CallExpr",
   BLOCK_STMT = "BlockStmt",
@@ -71,8 +81,8 @@ export interface FuncDecl extends Decl {
 
 export interface Expr {}
 
-export interface BasicLiteral extends Expr {
-  _type: NodeType.BASIC_LITERAL;
+export interface BasicLit extends Expr {
+  _type: NodeType.BASIC_LIT;
   Kind: string;
   Value: number | string;
 }
@@ -126,9 +136,8 @@ export interface ForStmt extends Stmt {
 }
 
 export interface ExprStmt extends Stmt {
-  // calling a function
   _type: NodeType.EXPR_STMT;
-  Expr: CallExpr;
+  X: Expr;
 }
 
 export interface ReturnStmt extends Stmt {

--- a/go-slang/src/types.ts
+++ b/go-slang/src/types.ts
@@ -5,6 +5,7 @@ export interface ParserResult {
 
 export interface RunnerResult {
   value?: string;
+  logs?: any[];
   error?: string;
 }
 

--- a/js-slang/src/createContext.ts
+++ b/js-slang/src/createContext.ts
@@ -638,6 +638,10 @@ export const importBuiltins = (context: Context, externalBuiltIns: CustomBuiltIn
       }
     }
   }
+
+  if (context.chapter === Chapter.GOLANG) {
+    defineBuiltin(context, 'Println(val)', display, 1)
+  }
 }
 
 function importPrelude(context: Context) {

--- a/js-slang/src/index.ts
+++ b/js-slang/src/index.ts
@@ -237,6 +237,10 @@ export async function runFilesInContext(
       // context.errors.push(result.error)
       return resolvedErrorPromise
     }
+
+    const println = context.nativeStorage.builtins.get('Println')
+    result.logs?.forEach(s => println(s))
+
     return {
       status: 'finished',
       context: context,

--- a/js-slang/src/index.ts
+++ b/js-slang/src/index.ts
@@ -232,10 +232,15 @@ export async function runFilesInContext(
   if (context.chapter === Chapter.GOLANG) {
     const runner = new GolangRunner()
     const result = await runner.execute(code)
+    if (result.error) {
+      // context.errors only accept errors with SourceError interface. to KIV
+      // context.errors.push(result.error)
+      return resolvedErrorPromise
+    }
     return {
       status: 'finished',
       context: context,
-      value: result
+      value: result.value
     }
   }
 


### PR DESCRIPTION
Relies in #7 as it branches off from that

Also realised that this model (where GoSlangRunner.execute returns an array of print statements) will not really work in future for concurrency or even when time.Sleep is introduced, but it should suffice for now when all programs are expected to finish executing immediately