### PR TITLE
Transition to low-level memory

### DIFF
--- a/go-slang/__tests__/runner.block.test.ts
+++ b/go-slang/__tests__/runner.block.test.ts
@@ -5,7 +5,7 @@ let golangRunner: GolangRunner;
 const println = jest.fn();
 beforeEach(() => {
   println.mockClear();
-  golangRunner = new GolangRunner({ Println: println });
+  golangRunner = new GolangRunner({ Println: { arity: 1, apply: println } });
 });
 
 describe("Golang runner for evaluating assignments in blocks", () => {

--- a/go-slang/__tests__/runner.function.test.ts
+++ b/go-slang/__tests__/runner.function.test.ts
@@ -184,11 +184,11 @@ describe("Golang runner for evaluating functions", () => {
     const program = `
     package main
 
-    func first() {
+    func first() int {
       return second()
     }
 
-    func second() {
+    func second() int {
       return 3
     }
   

--- a/go-slang/helper.ts
+++ b/go-slang/helper.ts
@@ -1,10 +1,14 @@
 // can be run using
-// npx ts-node test.ts
+// npx ts-node helper.ts
 
 import { GolangRunner } from "./src";
+import { BuiltinFunction } from "./src/types";
 
-const builtin_mapping: Record<string, any> = {
-  Println: (v: any) => console.log("Go program printed:", v),
+const builtin_mapping: Record<string, BuiltinFunction> = {
+  Println: {
+    arity: 1,
+    apply: (v: any) => console.log("Go program printed:", v),
+  },
 };
 const runner = new GolangRunner(builtin_mapping);
 const program = `

--- a/go-slang/src/compiler/index.ts
+++ b/go-slang/src/compiler/index.ts
@@ -188,7 +188,7 @@ export class GolangCompiler {
           }
         });
 
-        astNode.Lhs.reverse().forEach((ident) => {
+        astNode.Lhs.reverse().forEach((ident, i) => {
           if (
             astNode.Tok === Token.DEFINE &&
             !current_frame.includes(ident.Name)
@@ -201,7 +201,9 @@ export class GolangCompiler {
             sym: ident.Name,
             pos: this.cte_position(ident.Name),
           };
-          this.instrs[this.wc++] = { _type: "POP" };
+          if (i < astNode.Lhs.length - 1) {
+            this.instrs[this.wc++] = { _type: "POP" };
+          }
         });
       },
       Ident: (astNode: Ident) => {

--- a/go-slang/src/compiler/index.ts
+++ b/go-slang/src/compiler/index.ts
@@ -101,7 +101,6 @@ export class GolangCompiler {
         this.compile(astNode.X);
       },
       FuncDecl: (astNode: FuncDecl) => {
-        // compiling the function itself: params and body
         const params = astNode.Type.Params.List.flatMap((e) =>
           e.Names.map((name) => name.Name),
         );
@@ -119,12 +118,10 @@ export class GolangCompiler {
         goto_instruction.addr = this.wc;
         this.compile_env.pop();
 
-        // compiling the name of the function
-        const name = astNode.Name.Name;
         this.instrs[this.wc++] = {
           _type: "ASSIGN",
-          sym: name,
-          pos: this.cte_position(name),
+          sym: astNode.Name.Name,
+          pos: this.cte_position(astNode.Name.Name),
         };
       },
       CallExpr: (astNode: CallExpr) => {

--- a/go-slang/src/compiler/index.ts
+++ b/go-slang/src/compiler/index.ts
@@ -121,11 +121,6 @@ export class GolangCompiler {
 
         // compiling the name of the function
         const name = astNode.Name.Name;
-        const current_frame = peek(this.compile_env);
-        if (current_frame.includes(name)) {
-          throw new Error(`${name} redeclared in this block`);
-        }
-        current_frame.push(name);
         this.instrs[this.wc++] = { _type: "DEFINE", sym: name };
         this.instrs[this.wc++] = {
           _type: "ASSIGN",
@@ -145,7 +140,10 @@ export class GolangCompiler {
           return;
         }
 
-        this.compile_env.push([]);
+        const func_decls = astNode.List.filter(
+          (val) => val._type === NodeType.FUNC_DECL,
+        ).map((func) => (func as FuncDecl).Name.Name);
+        this.compile_env.push(func_decls);
         const enter_scope_instr: ENTER_SCOPE = { _type: "ENTER_SCOPE", num: 0 };
         this.instrs[this.wc++] = enter_scope_instr;
 

--- a/go-slang/src/compiler/index.ts
+++ b/go-slang/src/compiler/index.ts
@@ -121,7 +121,6 @@ export class GolangCompiler {
 
         // compiling the name of the function
         const name = astNode.Name.Name;
-        this.instrs[this.wc++] = { _type: "DEFINE", sym: name };
         this.instrs[this.wc++] = {
           _type: "ASSIGN",
           sym: name,
@@ -193,7 +192,6 @@ export class GolangCompiler {
             !current_frame.includes(ident.Name)
           ) {
             current_frame.push(ident.Name);
-            this.instrs[this.wc++] = { _type: "DEFINE", sym: ident.Name };
           }
           this.instrs[this.wc++] = {
             _type: "ASSIGN",

--- a/go-slang/src/compiler/index.ts
+++ b/go-slang/src/compiler/index.ts
@@ -1,3 +1,4 @@
+import { BuiltinFunction } from "../types";
 import {
   File,
   BasicLit,
@@ -63,10 +64,10 @@ export class GolangCompiler {
   private compile_ast: any;
   private compile_env: Array<Array<string>>; // stack of arrays
 
-  constructor() {
+  constructor(builtin_mapping: Record<string, BuiltinFunction>) {
     this.wc = 0;
     this.instrs = [];
-    this.compile_env = [];
+    this.compile_env = [Object.keys(builtin_mapping)];
     this.compile_ast = {
       BasicLit: (astNode: BasicLit) => {
         this.instrs[this.wc++] = {

--- a/go-slang/src/index.ts
+++ b/go-slang/src/index.ts
@@ -1,7 +1,7 @@
 import { GolangParser } from "./parser";
 import { GolangCompiler } from "./compiler";
 import { GolangVM } from "./vm";
-import { RunnerResult } from "./types";
+import { BuiltinFunction, RunnerResult } from "./types";
 
 // Facade class that contains parser, compiler and vm / main entry point
 export class GolangRunner {
@@ -9,9 +9,9 @@ export class GolangRunner {
   private compiler: GolangCompiler;
   private vm: GolangVM;
 
-  constructor(builtin_mapping: Record<string, any> = {}) {
+  constructor(builtin_mapping: Record<string, BuiltinFunction> = {}) {
     this.parser = new GolangParser();
-    this.compiler = new GolangCompiler();
+    this.compiler = new GolangCompiler(builtin_mapping);
     this.vm = new GolangVM(builtin_mapping);
   }
 

--- a/go-slang/src/types/index.ts
+++ b/go-slang/src/types/index.ts
@@ -2,3 +2,8 @@ export type RunnerResult = {
   value?: any;
   error?: string;
 };
+
+export type BuiltinFunction = {
+  arity: number;
+  apply: any;
+};

--- a/go-slang/src/types/vm_instructions.ts
+++ b/go-slang/src/types/vm_instructions.ts
@@ -29,11 +29,6 @@ export type RESET = {
   _type: "RESET";
 };
 
-export type DEFINE = {
-  _type: "DEFINE";
-  sym: string;
-};
-
 export type ASSIGN = {
   _type: "ASSIGN";
   sym: string;
@@ -82,7 +77,6 @@ export type Instruction =
   | GOTO
   | JOF
   | RESET
-  | DEFINE
   | ASSIGN
   | LDF
   | CALL

--- a/go-slang/src/types/vm_instructions.ts
+++ b/go-slang/src/types/vm_instructions.ts
@@ -37,6 +37,7 @@ export type DEFINE = {
 export type ASSIGN = {
   _type: "ASSIGN";
   sym: string;
+  pos: [number, number];
 };
 
 export type CALL = {
@@ -46,6 +47,7 @@ export type CALL = {
 
 export type ENTER_SCOPE = {
   _type: "ENTER_SCOPE";
+  num: number;
 };
 
 export type POP = {

--- a/go-slang/src/types/vm_instructions.ts
+++ b/go-slang/src/types/vm_instructions.ts
@@ -59,6 +59,7 @@ export type EXIT_SCOPE = {
 export type LD = {
   _type: "LD";
   sym: string;
+  pos: [number, number];
 };
 
 export type LDF = {

--- a/go-slang/src/vm/heap.ts
+++ b/go-slang/src/vm/heap.ts
@@ -1,0 +1,220 @@
+export enum Tag {
+  False,
+  True,
+  Number,
+  Nil,
+  Blockframe,
+  Callframe,
+  Closure,
+  Frame,
+  Environment,
+  Builtin,
+}
+
+export class Heap {
+  word_size = 8;
+  size_offset = 5;
+  node_size = 10;
+  free: number = 0;
+  heap_size: number;
+
+  view: DataView;
+
+  constructor(heap_size: number) {
+    this.heap_size = heap_size;
+    const data = new ArrayBuffer(heap_size * this.word_size);
+    this.view = new DataView(data);
+  }
+
+  allocate(tag: number, size: number): number {
+    const address = this.free;
+    this.free += size;
+    this.view.setUint8(address * this.word_size, tag);
+    this.view.setUint16(address * this.word_size + this.size_offset, size);
+    return address;
+  }
+
+  get(address: number) {
+    return this.view.getFloat64(address * this.word_size);
+  }
+
+  set(address: number, x: number) {
+    this.view.setFloat64(address * this.word_size, x);
+  }
+
+  get_child(address: number, child_index: number) {
+    return this.get(address + 1 + child_index);
+  }
+
+  set_child(address: number, child_index: number, value: any) {
+    this.set(address + 1 + child_index, value);
+  }
+
+  get_tag(address: number) {
+    return this.view.getUint8(address * this.word_size);
+  }
+
+  get_size(address: number) {
+    return this.view.getUint16(address * this.word_size + this.size_offset);
+  }
+
+  get_number_of_children(address: number) {
+    return this.get_tag(address) === Tag.Number
+      ? 0
+      : this.get_size(address) - 1;
+  }
+
+  set_byte_at_offset(address: number, offset: number, value: number) {
+    this.view.setUint8(address * this.word_size + offset, value);
+  }
+
+  get_byte_at_offset(address: number, offset: number) {
+    return this.view.getUint8(address * this.word_size + offset);
+  }
+
+  set_2_bytes_at_offset(address: number, offset: number, value: number) {
+    this.view.setUint16(address * this.word_size + offset, value);
+  }
+
+  get_2_bytes_at_offset(address: number, offset: number) {
+    return this.view.getUint16(address * this.word_size + offset);
+  }
+
+  set_4_bytes_at_offset(address: number, offset: number, value: number) {
+    this.view.setUint32(address * this.word_size + offset, value);
+  }
+
+  get_4_bytes_at_offset(address: number, offset: number) {
+    return this.view.getUint32(address * this.word_size + offset);
+  }
+}
+
+export class Memory {
+  heap: Heap;
+  False: number;
+  True: number;
+
+  constructor(heap_size: number) {
+    this.heap = new Heap(heap_size);
+    this.False = this.heap.allocate(Tag.False, 1);
+    this.True = this.heap.allocate(Tag.True, 1);
+  }
+
+  address_to_js_value(address: number) {
+    switch (this.heap.get_tag(address)) {
+      case Tag.False:
+        return false;
+      case Tag.True:
+        return true;
+      case Tag.Number:
+        return this.heap.get(address + 1);
+      case Tag.Closure:
+        return "<closure>";
+      case Tag.Builtin:
+        return "<builtin>";
+      default:
+        return "<internals>";
+    }
+  }
+
+  js_value_to_address(value: any) {
+    if (value === true) {
+      return this.True;
+    } else if (value === false) {
+      return this.False;
+    } else if (typeof value === "number") {
+      return this.number.allocate(value);
+    }
+    return -1;
+  }
+
+  number = {
+    allocate: (n: number) => {
+      const number_address = this.heap.allocate(Tag.Number, 2);
+      this.heap.set(number_address + 1, n);
+      return number_address;
+    },
+  };
+
+  builtin = {
+    allocate: (id: number) => {
+      const address = this.heap.allocate(Tag.Builtin, 1);
+      this.heap.set_byte_at_offset(address, 1, id);
+      return address;
+    },
+    get_id: (address: number) => this.heap.get_byte_at_offset(address, 1),
+  };
+
+  closure = {
+    allocate: (arity: number, pc: number, env: number) => {
+      const address = this.heap.allocate(Tag.Closure, 2);
+      this.heap.set_byte_at_offset(address, 1, arity);
+      this.heap.set_2_bytes_at_offset(address, 2, pc);
+      this.heap.set(address + 1, env);
+      return address;
+    },
+    get_arity: (address: number) => this.heap.get_byte_at_offset(address, 1),
+    get_pc: (address: number) => this.heap.get_2_bytes_at_offset(address, 2),
+    get_environment: (address: number) => this.heap.get_child(address, 0),
+  };
+
+  blockframe = {
+    allocate: (env: number) => {
+      const address = this.heap.allocate(Tag.Blockframe, 2);
+      this.heap.set(address + 1, env);
+      return address;
+    },
+    get_environment: (address: number) => this.heap.get_child(address, 0),
+  };
+
+  callframe = {
+    allocate: (env: number, pc: number) => {
+      const address = this.heap.allocate(Tag.Callframe, 2);
+      this.heap.set_2_bytes_at_offset(address, 2, pc);
+      this.heap.set(address + 1, env);
+      return address;
+    },
+    get_environment: (address: number) => this.heap.get_child(address, 0),
+    get_pc: (address: number) => this.heap.get_2_bytes_at_offset(address, 2),
+  };
+
+  frame = {
+    allocate: (num_values: number) => {
+      return this.heap.allocate(Tag.Frame, num_values + 1);
+    },
+  };
+
+  environment = {
+    allocate: (num_frames: number) => {
+      return this.heap.allocate(Tag.Environment, num_frames + 1);
+    },
+    get_value: (env_address: number, position: [number, number]) => {
+      const [frame_index, value_index] = position;
+      const frame_address = this.heap.get_child(env_address, frame_index);
+      return this.heap.get_child(frame_address, value_index);
+    },
+    set_value: (
+      env_address: number,
+      position: [number, number],
+      value: any,
+    ) => {
+      const [frame_index, value_index] = position;
+      const frame_address = this.heap.get_child(env_address, frame_index);
+      this.heap.set_child(frame_address, value_index, value);
+    },
+    extend: (frame_address: number, env_address: number) => {
+      const old_size = this.heap.get_size(env_address);
+      const new_env_address = this.environment.allocate(old_size);
+      let i;
+      for (i = 0; i < old_size - 1; i++) {
+        this.heap.set_child(
+          new_env_address,
+          i,
+          this.heap.get_child(env_address, i),
+        );
+      }
+      this.heap.set_child(new_env_address, i, frame_address);
+      return new_env_address;
+    },
+  };
+}

--- a/go-slang/src/vm/heap.ts
+++ b/go-slang/src/vm/heap.ts
@@ -1,15 +1,4 @@
-export enum Tag {
-  False,
-  True,
-  Number,
-  Nil,
-  Blockframe,
-  Callframe,
-  Closure,
-  Frame,
-  Environment,
-  Builtin,
-}
+import { Tag } from "./tag";
 
 export class Heap {
   word_size = 8;
@@ -26,7 +15,7 @@ export class Heap {
     this.view = new DataView(data);
   }
 
-  allocate(tag: number, size: number): number {
+  allocate(tag: Tag, size: number): number {
     const address = this.free;
     this.free += size;
     this.view.setUint8(address * this.word_size, tag);
@@ -87,134 +76,4 @@ export class Heap {
   get_4_bytes_at_offset(address: number, offset: number) {
     return this.view.getUint32(address * this.word_size + offset);
   }
-}
-
-export class Memory {
-  heap: Heap;
-  False: number;
-  True: number;
-
-  constructor(heap_size: number) {
-    this.heap = new Heap(heap_size);
-    this.False = this.heap.allocate(Tag.False, 1);
-    this.True = this.heap.allocate(Tag.True, 1);
-  }
-
-  address_to_js_value(address: number) {
-    switch (this.heap.get_tag(address)) {
-      case Tag.False:
-        return false;
-      case Tag.True:
-        return true;
-      case Tag.Number:
-        return this.heap.get(address + 1);
-      case Tag.Closure:
-        return "<closure>";
-      case Tag.Builtin:
-        return "<builtin>";
-      default:
-        return "<internals>";
-    }
-  }
-
-  js_value_to_address(value: any) {
-    if (value === true) {
-      return this.True;
-    } else if (value === false) {
-      return this.False;
-    } else if (typeof value === "number") {
-      return this.number.allocate(value);
-    }
-    return -1;
-  }
-
-  number = {
-    allocate: (n: number) => {
-      const number_address = this.heap.allocate(Tag.Number, 2);
-      this.heap.set(number_address + 1, n);
-      return number_address;
-    },
-  };
-
-  builtin = {
-    allocate: (id: number) => {
-      const address = this.heap.allocate(Tag.Builtin, 1);
-      this.heap.set_byte_at_offset(address, 1, id);
-      return address;
-    },
-    get_id: (address: number) => this.heap.get_byte_at_offset(address, 1),
-  };
-
-  closure = {
-    allocate: (arity: number, pc: number, env: number) => {
-      const address = this.heap.allocate(Tag.Closure, 2);
-      this.heap.set_byte_at_offset(address, 1, arity);
-      this.heap.set_2_bytes_at_offset(address, 2, pc);
-      this.heap.set(address + 1, env);
-      return address;
-    },
-    get_arity: (address: number) => this.heap.get_byte_at_offset(address, 1),
-    get_pc: (address: number) => this.heap.get_2_bytes_at_offset(address, 2),
-    get_environment: (address: number) => this.heap.get_child(address, 0),
-  };
-
-  blockframe = {
-    allocate: (env: number) => {
-      const address = this.heap.allocate(Tag.Blockframe, 2);
-      this.heap.set(address + 1, env);
-      return address;
-    },
-    get_environment: (address: number) => this.heap.get_child(address, 0),
-  };
-
-  callframe = {
-    allocate: (env: number, pc: number) => {
-      const address = this.heap.allocate(Tag.Callframe, 2);
-      this.heap.set_2_bytes_at_offset(address, 2, pc);
-      this.heap.set(address + 1, env);
-      return address;
-    },
-    get_environment: (address: number) => this.heap.get_child(address, 0),
-    get_pc: (address: number) => this.heap.get_2_bytes_at_offset(address, 2),
-  };
-
-  frame = {
-    allocate: (num_values: number) => {
-      return this.heap.allocate(Tag.Frame, num_values + 1);
-    },
-  };
-
-  environment = {
-    allocate: (num_frames: number) => {
-      return this.heap.allocate(Tag.Environment, num_frames + 1);
-    },
-    get_value: (env_address: number, position: [number, number]) => {
-      const [frame_index, value_index] = position;
-      const frame_address = this.heap.get_child(env_address, frame_index);
-      return this.heap.get_child(frame_address, value_index);
-    },
-    set_value: (
-      env_address: number,
-      position: [number, number],
-      value: any,
-    ) => {
-      const [frame_index, value_index] = position;
-      const frame_address = this.heap.get_child(env_address, frame_index);
-      this.heap.set_child(frame_address, value_index, value);
-    },
-    extend: (frame_address: number, env_address: number) => {
-      const old_size = this.heap.get_size(env_address);
-      const new_env_address = this.environment.allocate(old_size);
-      let i;
-      for (i = 0; i < old_size - 1; i++) {
-        this.heap.set_child(
-          new_env_address,
-          i,
-          this.heap.get_child(env_address, i),
-        );
-      }
-      this.heap.set_child(new_env_address, i, frame_address);
-      return new_env_address;
-    },
-  };
 }

--- a/go-slang/src/vm/index.ts
+++ b/go-slang/src/vm/index.ts
@@ -73,7 +73,11 @@ export class GolangVM {
 
   pop_os() {
     const address = this.OS.pop();
-    if (address === undefined) throw new Error(`Tried to pop from an empty OS`);
+    if (address === undefined) {
+      return undefined;
+      // TODO: throw error? sign that there is an unecessary pop
+      // throw new Error(`Tried to pop from an empty OS`);
+    }
     return this.memory.address_to_js_value(address);
   }
 

--- a/go-slang/src/vm/index.ts
+++ b/go-slang/src/vm/index.ts
@@ -176,12 +176,13 @@ export class GolangVM {
       CALL: (instr: CALL) => {
         const arity = instr.arity;
         let fun = peek(this.OS, arity);
+        const tag = this.memory.heap.get_tag(fun);
 
-        if (this.memory.heap.get_tag(fun) === Tag.Builtin) {
+        if (tag === Tag.Builtin) {
           return this.apply_builtin(this.memory.builtin.get_id(fun));
         }
 
-        if (this.memory.heap.get_tag(fun) === Tag.Closure) {
+        if (tag === Tag.Closure) {
           const frame_address = this.memory.frame.allocate(arity);
           for (let i = arity - 1; i >= 0; i--) {
             this.memory.heap.set_child(frame_address, i, this.OS.pop());
@@ -193,7 +194,10 @@ export class GolangVM {
             this.memory.closure.get_environment(fun),
           );
           this.PC = this.memory.closure.get_pc(fun);
+          return;
         }
+
+        throw new Error(`Tried to CALL on a non-function type: tag ${tag}`);
       },
       RESET: (instr: RESET) => {
         this.PC--;

--- a/go-slang/src/vm/index.ts
+++ b/go-slang/src/vm/index.ts
@@ -15,7 +15,6 @@ import {
   RESET,
   JOF,
   Instruction,
-  DEFINE,
 } from "../types/vm_instructions";
 import { Memory } from "./memory";
 import { Tag } from "./tag";
@@ -158,9 +157,6 @@ export class GolangVM {
       LD: (instr: LD) => {
         const val = this.memory.environment.get_value(this.E, instr.pos);
         this.OS.push(val);
-      },
-      DEFINE: (instr: DEFINE) => {
-        // TODO
       },
       ASSIGN: (instr: ASSIGN) => {
         this.memory.environment.set_value(this.E, instr.pos, peek(this.OS));

--- a/go-slang/src/vm/index.ts
+++ b/go-slang/src/vm/index.ts
@@ -97,7 +97,7 @@ export class GolangVM {
   }
 
   constructor(builtin_mapping: Record<string, BuiltinFunction>) {
-    this.memory = new Memory(1000000);
+    this.memory = new Memory(10000000);
     this.builtin_array = Object.values(builtin_mapping);
 
     const empty_environment = this.memory.environment.allocate(0);

--- a/go-slang/src/vm/memory.ts
+++ b/go-slang/src/vm/memory.ts
@@ -1,0 +1,132 @@
+import { Heap } from "./heap";
+import { Tag } from "./tag";
+
+export class Memory {
+  heap: Heap;
+  False: number;
+  True: number;
+
+  constructor(heap_size: number) {
+    this.heap = new Heap(heap_size);
+    this.False = this.heap.allocate(Tag.False, 1);
+    this.True = this.heap.allocate(Tag.True, 1);
+  }
+
+  address_to_js_value(address: number) {
+    switch (this.heap.get_tag(address)) {
+      case Tag.False:
+        return false;
+      case Tag.True:
+        return true;
+      case Tag.Number:
+        return this.heap.get(address + 1);
+      case Tag.Closure:
+        return "<closure>";
+      case Tag.Builtin:
+        return "<builtin>";
+      default:
+        return "<internals>";
+    }
+  }
+
+  js_value_to_address(value: any) {
+    if (value === true) {
+      return this.True;
+    } else if (value === false) {
+      return this.False;
+    } else if (typeof value === "number") {
+      return this.number.allocate(value);
+    }
+    return -1;
+  }
+
+  number = {
+    allocate: (n: number) => {
+      const number_address = this.heap.allocate(Tag.Number, 2);
+      this.heap.set(number_address + 1, n);
+      return number_address;
+    },
+  };
+
+  builtin = {
+    allocate: (id: number) => {
+      const address = this.heap.allocate(Tag.Builtin, 1);
+      this.heap.set_byte_at_offset(address, 1, id);
+      return address;
+    },
+    get_id: (address: number) => this.heap.get_byte_at_offset(address, 1),
+  };
+
+  closure = {
+    allocate: (arity: number, pc: number, env: number) => {
+      const address = this.heap.allocate(Tag.Closure, 2);
+      this.heap.set_byte_at_offset(address, 1, arity);
+      this.heap.set_2_bytes_at_offset(address, 2, pc);
+      this.heap.set(address + 1, env);
+      return address;
+    },
+    get_arity: (address: number) => this.heap.get_byte_at_offset(address, 1),
+    get_pc: (address: number) => this.heap.get_2_bytes_at_offset(address, 2),
+    get_environment: (address: number) => this.heap.get_child(address, 0),
+  };
+
+  blockframe = {
+    allocate: (env: number) => {
+      const address = this.heap.allocate(Tag.Blockframe, 2);
+      this.heap.set(address + 1, env);
+      return address;
+    },
+    get_environment: (address: number) => this.heap.get_child(address, 0),
+  };
+
+  callframe = {
+    allocate: (env: number, pc: number) => {
+      const address = this.heap.allocate(Tag.Callframe, 2);
+      this.heap.set_2_bytes_at_offset(address, 2, pc);
+      this.heap.set(address + 1, env);
+      return address;
+    },
+    get_environment: (address: number) => this.heap.get_child(address, 0),
+    get_pc: (address: number) => this.heap.get_2_bytes_at_offset(address, 2),
+  };
+
+  frame = {
+    allocate: (num_values: number) => {
+      return this.heap.allocate(Tag.Frame, num_values + 1);
+    },
+  };
+
+  environment = {
+    allocate: (num_frames: number) => {
+      return this.heap.allocate(Tag.Environment, num_frames + 1);
+    },
+    get_value: (env_address: number, position: [number, number]) => {
+      const [frame_index, value_index] = position;
+      const frame_address = this.heap.get_child(env_address, frame_index);
+      return this.heap.get_child(frame_address, value_index);
+    },
+    set_value: (
+      env_address: number,
+      position: [number, number],
+      value: any,
+    ) => {
+      const [frame_index, value_index] = position;
+      const frame_address = this.heap.get_child(env_address, frame_index);
+      this.heap.set_child(frame_address, value_index, value);
+    },
+    extend: (frame_address: number, env_address: number) => {
+      const old_size = this.heap.get_size(env_address);
+      const new_env_address = this.environment.allocate(old_size);
+      let i;
+      for (i = 0; i < old_size - 1; i++) {
+        this.heap.set_child(
+          new_env_address,
+          i,
+          this.heap.get_child(env_address, i),
+        );
+      }
+      this.heap.set_child(new_env_address, i, frame_address);
+      return new_env_address;
+    },
+  };
+}

--- a/go-slang/src/vm/memory.ts
+++ b/go-slang/src/vm/memory.ts
@@ -5,11 +5,14 @@ export class Memory {
   heap: Heap;
   False: number;
   True: number;
+  // TODO: go does not have undefined
+  Undefined: number;
 
   constructor(heap_size: number) {
     this.heap = new Heap(heap_size);
     this.False = this.heap.allocate(Tag.False, 1);
     this.True = this.heap.allocate(Tag.True, 1);
+    this.Undefined = this.heap.allocate(Tag.Undefined, 1);
   }
 
   address_to_js_value(address: number) {
@@ -18,6 +21,8 @@ export class Memory {
         return false;
       case Tag.True:
         return true;
+      case Tag.Undefined:
+        return undefined;
       case Tag.Number:
         return this.heap.get(address + 1);
       case Tag.Closure:
@@ -34,10 +39,12 @@ export class Memory {
       return this.True;
     } else if (value === false) {
       return this.False;
+    } else if (value === undefined) {
+      return this.Undefined;
     } else if (typeof value === "number") {
       return this.number.allocate(value);
     }
-    return -1;
+    throw new Error(`Could not convert JS value ${value} to address`);
   }
 
   number = {

--- a/go-slang/src/vm/tag.ts
+++ b/go-slang/src/vm/tag.ts
@@ -1,0 +1,12 @@
+export enum Tag {
+  False,
+  True,
+  Number,
+  Nil,
+  Blockframe,
+  Callframe,
+  Closure,
+  Frame,
+  Environment,
+  Builtin,
+}

--- a/go-slang/src/vm/tag.ts
+++ b/go-slang/src/vm/tag.ts
@@ -1,8 +1,9 @@
 export enum Tag {
   False,
   True,
-  Number,
+  Undefined,
   Nil,
+  Number,
   Blockframe,
   Callframe,
   Closure,


### PR DESCRIPTION
Closes #16 

Implements low-level memory using `ArrayBuffer`

Changes

- Compile environment is no longer a stack of sets, but a stack of arrays. This is because each name in the program must have a fixed index, as it will later be referred to only by its frame index and its position in the frame.
- Fix compile-time environment for function params: function declarations create a new frame (to mirror the behaviour of the runtime environment) which contains the function params
- Fix extra POP after ASSIGN: the last ASSIGN should not pop, similar to the behaviour of block statements where the last statement does not have a POP after it