### PR TITLE
Refactor compiler and VM

### DIFF
--- a/go-slang/src/compiler/index.ts
+++ b/go-slang/src/compiler/index.ts
@@ -33,213 +33,32 @@ import {
 export class GolangCompiler {
   private wc: number;
   private instrs: Array<Instruction>;
-  private compile_ast: any;
   private compile_env: Array<Array<string>>; // stack of arrays
 
   constructor(builtin_mapping: Record<string, BuiltinFunction>) {
     this.wc = 0;
     this.instrs = [];
     this.compile_env = [Object.keys(builtin_mapping)];
-    this.compile_ast = {
-      BasicLit: (astNode: BasicLit) => {
-        this.instrs[this.wc++] = {
-          _type: "LDC",
-          val:
-            astNode.Kind === "STRING"
-              ? stripQuotes(astNode.Value as string)
-              : Number(astNode.Value), // can handle integers and floating point values
-        };
-      },
-      BinaryExpr: (astNode: BinaryExpr) => {
-        if (astNode.Op === Token.LAND) {
-          // X && Y is "if X then Y else false"
-          const falseExpr: Ident = { _type: NodeType.IDENT, Name: "false" };
-          return this.compile_conditional(astNode.X, astNode.Y, falseExpr);
-        }
-        if (astNode.Op === Token.LOR) {
-          // X || Y is "if X then true else Y"
-          const trueExpr: Ident = { _type: NodeType.IDENT, Name: "true" };
-          return this.compile_conditional(astNode.X, trueExpr, astNode.Y);
-        }
-        this.compile(astNode.X);
-        this.compile(astNode.Y);
-        this.instrs[this.wc++] = { _type: "BINOP", sym: astNode.Op };
-      },
-      UnaryExpr: (astNode: UnaryExpr) => {
-        this.compile(astNode.X);
-        this.instrs[this.wc++] = { _type: "UNOP", sym: astNode.Op };
-      },
-      ParenExpr: (astNode: ParenExpr) => {
-        this.compile(astNode.X);
-      },
-      FuncDecl: (astNode: FuncDecl) => {
-        const params = astNode.Type.Params.List.flatMap((e) =>
-          e.Names.map((name) => name.Name),
-        );
-        this.compile_env.push(params);
-        this.instrs[this.wc++] = {
-          _type: "LDF",
-          params: params,
-          addr: this.wc + 1,
-        };
-        const goto_instruction: GOTO = { _type: "GOTO", addr: -1 };
-        this.instrs[this.wc++] = goto_instruction;
-        this.compile(astNode.Body);
-        this.instrs[this.wc++] = { _type: "LDC", val: undefined };
-        this.instrs[this.wc++] = { _type: "RESET" };
-        goto_instruction.addr = this.wc;
-        this.compile_env.pop();
+  }
 
-        this.instrs[this.wc++] = {
-          _type: "ASSIGN",
-          sym: astNode.Name.Name,
-          pos: this.cte_position(astNode.Name.Name),
-        };
-      },
-      CallExpr: (astNode: CallExpr) => {
-        this.compile(astNode.Fun);
-        astNode.Args.forEach((arg) => this.compile(arg));
-        this.instrs[this.wc++] = { _type: "CALL", arity: astNode.Args.length };
-      },
-      BlockStmt: (astNode: BlockStmt) => {
-        // empty block
-        if (astNode.List.length === 0) {
-          this.instrs[this.wc++] = { _type: "LDC", val: undefined };
-          return;
-        }
-
-        const func_decls = astNode.List.filter(
-          (val) => val._type === NodeType.FUNC_DECL,
-        ).map((func) => (func as FuncDecl).Name.Name);
-        this.compile_env.push(func_decls);
-        const enter_scope_instr: ENTER_SCOPE = { _type: "ENTER_SCOPE", num: 0 };
-        this.instrs[this.wc++] = enter_scope_instr;
-
-        astNode.List.forEach((stmt, i) => {
-          this.compile(stmt);
-          if (i < astNode.List.length - 1) {
-            this.instrs[this.wc++] = { _type: "POP" };
-          }
-        });
-
-        this.instrs[this.wc++] = { _type: "EXIT_SCOPE" };
-        enter_scope_instr.num = peek(this.compile_env).length;
-        this.compile_env.pop();
-      },
-      AssignStmt: (astNode: AssignStmt) => {
-        const current_frame = peek(this.compile_env);
-        if (
-          astNode.Tok === Token.DEFINE &&
-          noNewVariables(astNode.Lhs, current_frame)
-        ) {
-          throw new Error("no new variables on left side of :=");
-        }
-
-        astNode.Rhs.forEach((expr, i) => {
-          if (astNode.Tok === Token.DEFINE || astNode.Tok === Token.ASSIGN) {
-            // simple assignment
-            this.compile(expr);
-          } else {
-            // compound assignment: +=, -=, *=, /= etc
-            const Op = compoundAssignmentToBinaryOperator.get(astNode.Tok);
-            if (Op === undefined) {
-              throw new Error(`operator not implemented: ${astNode.Tok}`);
-            }
-            const desugared: BinaryExpr = {
-              _type: NodeType.BINARY_EXPR,
-              Op,
-              X: astNode.Lhs[i],
-              Y: expr,
-            };
-            this.compile(desugared);
-          }
-        });
-
-        astNode.Lhs.reverse().forEach((ident, i) => {
-          if (
-            astNode.Tok === Token.DEFINE &&
-            !current_frame.includes(ident.Name)
-          ) {
-            current_frame.push(ident.Name);
-          }
-          this.instrs[this.wc++] = {
-            _type: "ASSIGN",
-            sym: ident.Name,
-            pos: this.cte_position(ident.Name),
-          };
-          if (i < astNode.Lhs.length - 1) {
-            this.instrs[this.wc++] = { _type: "POP" };
-          }
-        });
-      },
-      Ident: (astNode: Ident) => {
-        const name = astNode.Name;
-        let instr: Instruction;
-        // Go treats boolean as Ident. Adds a LDC instruction
-        // TODO: feel like the proper way to handle this would be to add it to the environment
-        // and continue treating it like an Ident / LD instruction
-        if (name === "true" || name === "false") {
-          instr = {
-            _type: "LDC",
-            val: name === "true",
-          };
-        } else {
-          instr = {
-            _type: "LD",
-            sym: name,
-            pos: this.cte_position(name),
-          };
-        }
-        this.instrs[this.wc++] = instr;
-      },
-      ReturnStmt: (astNode: ReturnStmt) => {
-        astNode.Results.forEach((result) => {
-          this.compile(result);
-        });
-        this.instrs[this.wc++] = { _type: "RESET" };
-      },
-      ExprStmt: (astNode: ExprStmt) => {
-        this.compile(astNode.X);
-      },
-      IfStmt: (astNode: IfStmt) => {
-        this.compile_conditional(
-          astNode.Cond,
-          astNode.Body,
-          astNode.Else ?? { _type: NodeType.BLOCK_STMT, List: [] },
-        );
-      },
-      ForStmt: (astNode: ForStmt) => {
-        const loop_start = this.wc;
-        this.compile(astNode.Cond);
-        const jump_on_false_instruction: JOF = { _type: "JOF", addr: -1 };
-        this.instrs[this.wc++] = jump_on_false_instruction;
-        this.compile(astNode.Body);
-        this.instrs[this.wc++] = { _type: "POP" };
-        this.instrs[this.wc++] = { _type: "GOTO", addr: loop_start };
-        jump_on_false_instruction.addr = this.wc;
-      },
-      IncDecStmt: (astNode: IncDecStmt) => {
-        // x++ desugar to x = x + 1
-        const one_literal_ast: BasicLit = {
-          _type: NodeType.BASIC_LIT,
-          Kind: "INT",
-          Value: "1",
-        };
-        const binary_expr_ast: BinaryExpr = {
-          _type: NodeType.BINARY_EXPR,
-          Op: astNode.Tok === Token.INC ? Token.ADD : Token.SUB,
-          X: astNode.X,
-          Y: one_literal_ast,
-        };
-        const assign_stmt_ast: AssignStmt = {
-          _type: NodeType.ASSIGN_STMT,
-          Lhs: [astNode.X],
-          Rhs: [binary_expr_ast],
-          Tok: Token.ASSIGN,
-        };
-        this.compile(assign_stmt_ast);
-      },
+  compile_program(rootAstNode: File) {
+    const block: BlockStmt = {
+      _type: NodeType.BLOCK_STMT,
+      List: [...rootAstNode.Decls, MAIN_CALL],
     };
+
+    this.compile(block);
+    this.instrs[this.wc] = { _type: "DONE" };
+    return this.instrs;
+  }
+
+  private compile(astNode: Node) {
+    if (this.compile_ast[astNode._type] !== undefined) {
+      this.compile_ast[astNode._type](astNode);
+    } else {
+      console.error(astNode);
+      throw new Error(`${astNode._type} not implemented`); // to make TDD tests fail
+    }
   }
 
   private cte_position(name: string): [number, number] {
@@ -269,23 +88,210 @@ export class GolangCompiler {
     goto_instruction.addr = this.wc;
   }
 
-  private compile(astNode: Node) {
-    if (this.compile_ast[astNode._type] !== undefined) {
-      this.compile_ast[astNode._type](astNode);
-    } else {
-      console.error(astNode);
-      throw new Error(`${astNode._type} not implemented`); // to make TDD tests fail
-    }
-  }
+  private compile_ast: Record<NodeType, any> = {
+    BasicLit: (astNode: BasicLit) => {
+      this.instrs[this.wc++] = {
+        _type: "LDC",
+        val:
+          astNode.Kind === "STRING"
+            ? stripQuotes(astNode.Value as string)
+            : Number(astNode.Value), // can handle integers and floating point values
+      };
+    },
+    BinaryExpr: (astNode: BinaryExpr) => {
+      if (astNode.Op === Token.LAND) {
+        // X && Y is "if X then Y else false"
+        const falseExpr: Ident = { _type: NodeType.IDENT, Name: "false" };
+        return this.compile_conditional(astNode.X, astNode.Y, falseExpr);
+      }
+      if (astNode.Op === Token.LOR) {
+        // X || Y is "if X then true else Y"
+        const trueExpr: Ident = { _type: NodeType.IDENT, Name: "true" };
+        return this.compile_conditional(astNode.X, trueExpr, astNode.Y);
+      }
+      this.compile(astNode.X);
+      this.compile(astNode.Y);
+      this.instrs[this.wc++] = { _type: "BINOP", sym: astNode.Op };
+    },
+    UnaryExpr: (astNode: UnaryExpr) => {
+      this.compile(astNode.X);
+      this.instrs[this.wc++] = { _type: "UNOP", sym: astNode.Op };
+    },
+    ParenExpr: (astNode: ParenExpr) => {
+      this.compile(astNode.X);
+    },
+    FuncDecl: (astNode: FuncDecl) => {
+      const params = astNode.Type.Params.List.flatMap((e) =>
+        e.Names.map((name) => name.Name),
+      );
+      this.compile_env.push(params);
+      this.instrs[this.wc++] = {
+        _type: "LDF",
+        params: params,
+        addr: this.wc + 1,
+      };
+      const goto_instruction: GOTO = { _type: "GOTO", addr: -1 };
+      this.instrs[this.wc++] = goto_instruction;
+      this.compile(astNode.Body);
+      this.instrs[this.wc++] = { _type: "LDC", val: undefined };
+      this.instrs[this.wc++] = { _type: "RESET" };
+      goto_instruction.addr = this.wc;
+      this.compile_env.pop();
 
-  compile_program(rootAstNode: File) {
-    const block: BlockStmt = {
-      _type: NodeType.BLOCK_STMT,
-      List: [...rootAstNode.Decls, main_call],
-    };
+      this.instrs[this.wc++] = {
+        _type: "ASSIGN",
+        sym: astNode.Name.Name,
+        pos: this.cte_position(astNode.Name.Name),
+      };
+    },
+    CallExpr: (astNode: CallExpr) => {
+      this.compile(astNode.Fun);
+      astNode.Args.forEach((arg) => this.compile(arg));
+      this.instrs[this.wc++] = { _type: "CALL", arity: astNode.Args.length };
+    },
+    BlockStmt: (astNode: BlockStmt) => {
+      // empty block
+      if (astNode.List.length === 0) {
+        this.instrs[this.wc++] = { _type: "LDC", val: undefined };
+        return;
+      }
 
-    this.compile(block);
-    this.instrs[this.wc] = { _type: "DONE" };
-    return this.instrs;
-  }
+      const func_decls = astNode.List.filter(
+        (val) => val._type === NodeType.FUNC_DECL,
+      ).map((func) => (func as FuncDecl).Name.Name);
+      this.compile_env.push(func_decls);
+      const enter_scope_instr: ENTER_SCOPE = { _type: "ENTER_SCOPE", num: 0 };
+      this.instrs[this.wc++] = enter_scope_instr;
+
+      astNode.List.forEach((stmt, i) => {
+        this.compile(stmt);
+        if (i < astNode.List.length - 1) {
+          this.instrs[this.wc++] = { _type: "POP" };
+        }
+      });
+
+      this.instrs[this.wc++] = { _type: "EXIT_SCOPE" };
+      enter_scope_instr.num = peek(this.compile_env).length;
+      this.compile_env.pop();
+    },
+    AssignStmt: (astNode: AssignStmt) => {
+      const current_frame = peek(this.compile_env);
+      if (
+        astNode.Tok === Token.DEFINE &&
+        noNewVariables(astNode.Lhs, current_frame)
+      ) {
+        throw new Error("no new variables on left side of :=");
+      }
+
+      astNode.Rhs.forEach((expr, i) => {
+        if (astNode.Tok === Token.DEFINE || astNode.Tok === Token.ASSIGN) {
+          // simple assignment
+          this.compile(expr);
+        } else {
+          // compound assignment: +=, -=, *=, /= etc
+          const Op = compoundAssignmentToBinaryOperator.get(astNode.Tok);
+          if (Op === undefined) {
+            throw new Error(`operator not implemented: ${astNode.Tok}`);
+          }
+          const desugared: BinaryExpr = {
+            _type: NodeType.BINARY_EXPR,
+            Op,
+            X: astNode.Lhs[i],
+            Y: expr,
+          };
+          this.compile(desugared);
+        }
+      });
+
+      astNode.Lhs.reverse().forEach((ident, i) => {
+        if (
+          astNode.Tok === Token.DEFINE &&
+          !current_frame.includes(ident.Name)
+        ) {
+          current_frame.push(ident.Name);
+        }
+        this.instrs[this.wc++] = {
+          _type: "ASSIGN",
+          sym: ident.Name,
+          pos: this.cte_position(ident.Name),
+        };
+        if (i < astNode.Lhs.length - 1) {
+          this.instrs[this.wc++] = { _type: "POP" };
+        }
+      });
+    },
+    Ident: (astNode: Ident) => {
+      const name = astNode.Name;
+      let instr: Instruction;
+      // Go treats boolean as Ident. Adds a LDC instruction
+      // TODO: feel like the proper way to handle this would be to add it to the environment
+      // and continue treating it like an Ident / LD instruction
+      if (name === "true" || name === "false") {
+        instr = {
+          _type: "LDC",
+          val: name === "true",
+        };
+      } else {
+        instr = {
+          _type: "LD",
+          sym: name,
+          pos: this.cte_position(name),
+        };
+      }
+      this.instrs[this.wc++] = instr;
+    },
+    ReturnStmt: (astNode: ReturnStmt) => {
+      astNode.Results.forEach((result) => {
+        this.compile(result);
+      });
+      this.instrs[this.wc++] = { _type: "RESET" };
+    },
+    ExprStmt: (astNode: ExprStmt) => {
+      this.compile(astNode.X);
+    },
+    IfStmt: (astNode: IfStmt) => {
+      this.compile_conditional(
+        astNode.Cond,
+        astNode.Body,
+        astNode.Else ?? { _type: NodeType.BLOCK_STMT, List: [] },
+      );
+    },
+    ForStmt: (astNode: ForStmt) => {
+      const loop_start = this.wc;
+      this.compile(astNode.Cond);
+      const jump_on_false_instruction: JOF = { _type: "JOF", addr: -1 };
+      this.instrs[this.wc++] = jump_on_false_instruction;
+      this.compile(astNode.Body);
+      this.instrs[this.wc++] = { _type: "POP" };
+      this.instrs[this.wc++] = { _type: "GOTO", addr: loop_start };
+      jump_on_false_instruction.addr = this.wc;
+    },
+    IncDecStmt: (astNode: IncDecStmt) => {
+      // x++ desugar to x = x + 1
+      const one_literal_ast: BasicLit = {
+        _type: NodeType.BASIC_LIT,
+        Kind: "INT",
+        Value: "1",
+      };
+      const binary_expr_ast: BinaryExpr = {
+        _type: NodeType.BINARY_EXPR,
+        Op: astNode.Tok === Token.INC ? Token.ADD : Token.SUB,
+        X: astNode.X,
+        Y: one_literal_ast,
+      };
+      const assign_stmt_ast: AssignStmt = {
+        _type: NodeType.ASSIGN_STMT,
+        Lhs: [astNode.X],
+        Rhs: [binary_expr_ast],
+        Tok: Token.ASSIGN,
+      };
+      this.compile(assign_stmt_ast);
+    },
+    File: () => {
+      throw new Error(`File not implemented`);
+    },
+    BranchStmt: () => {
+      throw new Error(`BranchStmt not implemented`);
+    },
+  };
 }

--- a/go-slang/src/compiler/index.ts
+++ b/go-slang/src/compiler/index.ts
@@ -22,41 +22,13 @@ import {
 } from "../types/ast";
 
 import { GOTO, JOF, Instruction, ENTER_SCOPE } from "../types/vm_instructions";
-
-function stripQuotes(str: string) {
-  return str.replace(/^"|"$/g, "");
-}
-
-function peek<T>(stack: Array<T>): T {
-  return stack[stack.length - 1];
-}
-
-const compoundAssignmentToBinaryOperator = new Map([
-  [Token.ADD_ASSIGN, Token.ADD],
-  [Token.SUB_ASSIGN, Token.SUB],
-  [Token.MUL_ASSIGN, Token.MUL],
-  [Token.QUO_ASSIGN, Token.QUO],
-  [Token.REM_ASSIGN, Token.REM],
-  [Token.AND_ASSIGN, Token.AND],
-  [Token.OR_ASSIGN, Token.OR],
-  [Token.XOR_ASSIGN, Token.XOR],
-  [Token.SHL_ASSIGN, Token.SHL],
-  [Token.SHR_ASSIGN, Token.SHR],
-  [Token.AND_NOT_ASSIGN, Token.AND_NOT],
-]);
-
-function noNewVariables(identifiers: Ident[], curr_env_frame: Array<string>) {
-  return identifiers.every((ident) => curr_env_frame.includes(ident.Name));
-}
-
-const main_call: CallExpr = {
-  _type: NodeType.CALL_EXPR,
-  Args: [],
-  Fun: {
-    _type: NodeType.IDENT,
-    Name: "main",
-  },
-};
+import { peek } from "../utils";
+import {
+  MAIN_CALL,
+  stripQuotes,
+  noNewVariables,
+  compoundAssignmentToBinaryOperator,
+} from "./utils";
 
 export class GolangCompiler {
   private wc: number;

--- a/go-slang/src/compiler/utils.ts
+++ b/go-slang/src/compiler/utils.ts
@@ -1,0 +1,35 @@
+import { Token, Ident, CallExpr, NodeType } from "../types/ast";
+
+export function stripQuotes(str: string) {
+  return str.replace(/^"|"$/g, "");
+}
+
+export const compoundAssignmentToBinaryOperator = new Map([
+  [Token.ADD_ASSIGN, Token.ADD],
+  [Token.SUB_ASSIGN, Token.SUB],
+  [Token.MUL_ASSIGN, Token.MUL],
+  [Token.QUO_ASSIGN, Token.QUO],
+  [Token.REM_ASSIGN, Token.REM],
+  [Token.AND_ASSIGN, Token.AND],
+  [Token.OR_ASSIGN, Token.OR],
+  [Token.XOR_ASSIGN, Token.XOR],
+  [Token.SHL_ASSIGN, Token.SHL],
+  [Token.SHR_ASSIGN, Token.SHR],
+  [Token.AND_NOT_ASSIGN, Token.AND_NOT],
+]);
+
+export function noNewVariables(
+  identifiers: Ident[],
+  curr_env_frame: Array<string>,
+) {
+  return identifiers.every((ident) => curr_env_frame.includes(ident.Name));
+}
+
+export const MAIN_CALL: CallExpr = {
+  _type: NodeType.CALL_EXPR,
+  Args: [],
+  Fun: {
+    _type: NodeType.IDENT,
+    Name: "main",
+  },
+};

--- a/go-slang/src/types/ast.ts
+++ b/go-slang/src/types/ast.ts
@@ -19,6 +19,7 @@ export enum NodeType {
   BINARY_EXPR = "BinaryExpr",
   UNARY_EXPR = "UnaryExpr",
   CALL_EXPR = "CallExpr",
+  PAREN_EXPR = "ParenExpr",
   BLOCK_STMT = "BlockStmt",
   ASSIGN_STMT = "AssignStmt",
   FOR_STMT = "ForStmt",
@@ -204,6 +205,7 @@ export interface UnaryExpr extends Expr {
 }
 
 export interface ParenExpr extends Expr {
+  _type: NodeType.PAREN_EXPR;
   X: Expr;
 }
 

--- a/go-slang/src/utils.ts
+++ b/go-slang/src/utils.ts
@@ -3,3 +3,8 @@ export const is_number = (val: any) => typeof val === "number";
 export const is_string = (val: any) => typeof val === "string";
 
 export const is_boolean = (val: any) => typeof val === "boolean";
+
+export function peek<T>(stack: Array<T>, index: number = 0) {
+  if (stack.length === 0) throw new Error("Stack is empty!");
+  return stack[stack.length - 1 - index];
+}

--- a/go-slang/src/vm/index.ts
+++ b/go-slang/src/vm/index.ts
@@ -1,5 +1,4 @@
 import { BuiltinFunction } from "../types";
-import { Token } from "../types/ast";
 import {
   LDC,
   UNOP,
@@ -16,48 +15,10 @@ import {
   JOF,
   Instruction,
 } from "../types/vm_instructions";
+import { peek } from "../utils";
 import { Memory } from "./memory";
 import { Tag } from "./tag";
-import { is_number, is_string, is_boolean } from "../utils";
-
-function peek<T>(stack: Array<T>, index: number = 0) {
-  if (stack.length === 0) throw new Error("Stack is empty!");
-  return stack[stack.length - 1 - index];
-}
-
-const binop_microcode: any = {
-  "+": (x: any, y: any) => {
-    if (!(is_number(x) && is_number(y)) && !(is_string(x) && is_string(y)))
-      throw new Error(`Expects two numbers or strings, got: ${x}, ${y}`);
-    return x + y;
-  },
-  "-": (x: number, y: number) => x - y,
-  "*": (x: number, y: number) => x * y,
-  "/": (x: number, y: number) => x / y,
-  "%": (x: number, y: number) => x % y,
-  "<": (x: number, y: number) => x < y,
-  "<=": (x: number, y: number) => x <= y,
-  ">=": (x: number, y: number) => x >= y,
-  ">": (x: number, y: number) => x > y,
-  "==": (x: number, y: number) => x === y,
-  "!=": (x: number, y: number) => x !== y,
-};
-
-const apply_binop = (op: Token, v2: any, v1: any) =>
-  binop_microcode[op](v1, v2);
-
-const unop_microcode: any = {
-  "-": (x: number) => {
-    if (!is_number(x)) throw new Error(`- expects a number, got: ${x}`);
-    return -x;
-  },
-  "!": (x: boolean) => {
-    if (!is_boolean(x)) throw new Error(`! expects a boolean, got: ${x}`);
-    return !x;
-  },
-};
-
-const apply_unop = (op: Token, v: any) => unop_microcode[op](v);
+import { apply_unop, apply_binop } from "./utils";
 
 export class GolangVM {
   private OS: Array<number>;

--- a/go-slang/src/vm/index.ts
+++ b/go-slang/src/vm/index.ts
@@ -14,6 +14,7 @@ import {
   RESET,
   JOF,
   Instruction,
+  DONE,
 } from "../types/vm_instructions";
 import { peek } from "../utils";
 import { Memory } from "./memory";
@@ -26,37 +27,19 @@ export class GolangVM {
   private E: number;
   private RTS: Array<number>;
   private memory: Memory;
-  private microcode: any;
   private builtin_array: Array<BuiltinFunction>;
-
-  pop_os() {
-    const address = this.OS.pop();
-    if (address === undefined) {
-      return undefined;
-      // TODO: throw error? sign that there is an unecessary pop
-      // throw new Error(`Tried to pop from an empty OS`);
-    }
-    return this.memory.address_to_js_value(address);
-  }
-
-  push_os(value: any) {
-    this.OS.push(this.memory.js_value_to_address(value));
-  }
-
-  apply_builtin(id: number) {
-    const { arity, apply } = this.builtin_array[id];
-    const args = [];
-    for (let i = 0; i < arity; i++) {
-      args.push(this.pop_os());
-    }
-    const result = apply.apply(null, args);
-    this.push_os(result);
-  }
 
   constructor(builtin_mapping: Record<string, BuiltinFunction>) {
     this.memory = new Memory(10000000);
     this.builtin_array = Object.values(builtin_mapping);
 
+    this.OS = [];
+    this.PC = 0;
+    this.RTS = [];
+    this.E = this.initialise_environment();
+  }
+
+  private initialise_environment() {
     const empty_environment = this.memory.environment.allocate(0);
     const global_frame = this.memory.frame.allocate(this.builtin_array.length);
 
@@ -68,102 +51,7 @@ export class GolangVM {
       );
     });
 
-    const global_environment = this.memory.environment.extend(
-      global_frame,
-      empty_environment,
-    );
-
-    this.OS = [];
-    this.PC = 0;
-    this.RTS = [];
-    this.E = global_environment;
-    this.microcode = {
-      LDC: (instr: LDC) => {
-        this.push_os(instr.val);
-      },
-      UNOP: (instr: UNOP) => {
-        this.push_os(apply_unop(instr.sym, this.pop_os()));
-      },
-      BINOP: (instr: BINOP) => {
-        this.push_os(apply_binop(instr.sym, this.pop_os(), this.pop_os()));
-      },
-      POP: (instr: POP) => {
-        this.pop_os();
-      },
-      JOF: (instr: JOF) => {
-        this.PC = this.pop_os() ? this.PC : instr.addr;
-      },
-      GOTO: (instr: GOTO) => {
-        this.PC = instr.addr;
-      },
-      ENTER_SCOPE: (instr: ENTER_SCOPE) => {
-        this.RTS.push(this.memory.blockframe.allocate(this.E));
-        const frame_address = this.memory.frame.allocate(instr.num);
-        this.E = this.memory.environment.extend(frame_address, this.E);
-        for (let i = 0; i < instr.num; i++) {
-          // initialise variables to 0
-          // TODO: how to initialise the variables? unassigned?
-          this.memory.heap.set_child(frame_address, i, 0);
-        }
-      },
-      EXIT_SCOPE: (instr: EXIT_SCOPE) => {
-        const scope = this.RTS.pop();
-        if (scope === undefined)
-          throw new Error(`Tried to exit scope when RTS is empty`);
-        this.E = this.memory.blockframe.get_environment(scope);
-      },
-      LD: (instr: LD) => {
-        const val = this.memory.environment.get_value(this.E, instr.pos);
-        this.OS.push(val);
-      },
-      ASSIGN: (instr: ASSIGN) => {
-        this.memory.environment.set_value(this.E, instr.pos, peek(this.OS));
-      },
-      LDF: (instr: LDF) => {
-        const closure_address = this.memory.closure.allocate(
-          instr.params.length,
-          instr.addr,
-          this.E,
-        );
-        this.OS.push(closure_address);
-      },
-      CALL: (instr: CALL) => {
-        const arity = instr.arity;
-        let fun = peek(this.OS, arity);
-        const tag = this.memory.heap.get_tag(fun);
-
-        if (tag === Tag.Builtin) {
-          return this.apply_builtin(this.memory.builtin.get_id(fun));
-        }
-
-        if (tag === Tag.Closure) {
-          const frame_address = this.memory.frame.allocate(arity);
-          for (let i = arity - 1; i >= 0; i--) {
-            this.memory.heap.set_child(frame_address, i, this.OS.pop());
-          }
-          this.OS.pop(); // pop fun
-          this.RTS.push(this.memory.callframe.allocate(this.E, this.PC));
-          this.E = this.memory.environment.extend(
-            frame_address,
-            this.memory.closure.get_environment(fun),
-          );
-          this.PC = this.memory.closure.get_pc(fun);
-          return;
-        }
-
-        throw new Error(`Tried to CALL on a non-function type: tag ${tag}`);
-      },
-      RESET: (instr: RESET) => {
-        this.PC--;
-        const top_frame = this.RTS.pop();
-        if (top_frame === undefined) {
-          throw new Error(`Tried to RESET where RTS is empty`);
-        }
-        if (this.memory.heap.get_tag(top_frame) === Tag.Callframe)
-          this.PC = this.memory.callframe.get_pc(top_frame);
-        this.E = this.memory.callframe.get_environment(top_frame);
-      },
-    };
+    return this.memory.environment.extend(global_frame, empty_environment);
   }
 
   run(instrs: Instruction[]) {
@@ -177,4 +65,117 @@ export class GolangVM {
     }
     return this.pop_os();
   }
+
+  private pop_os() {
+    const address = this.OS.pop();
+    if (address === undefined) {
+      return undefined;
+      // TODO: throw error? sign that there is an unecessary pop
+      // throw new Error(`Tried to pop from an empty OS`);
+    }
+    return this.memory.address_to_js_value(address);
+  }
+
+  private push_os(value: any) {
+    this.OS.push(this.memory.js_value_to_address(value));
+  }
+
+  private apply_builtin(id: number) {
+    const { arity, apply } = this.builtin_array[id];
+    const args = [];
+    for (let i = 0; i < arity; i++) {
+      args.push(this.pop_os());
+    }
+    const result = apply.apply(null, args);
+    this.push_os(result);
+  }
+
+  private microcode: Record<Instruction["_type"], any> = {
+    LDC: (instr: LDC) => {
+      this.push_os(instr.val);
+    },
+    UNOP: (instr: UNOP) => {
+      this.push_os(apply_unop(instr.sym, this.pop_os()));
+    },
+    BINOP: (instr: BINOP) => {
+      this.push_os(apply_binop(instr.sym, this.pop_os(), this.pop_os()));
+    },
+    POP: (instr: POP) => {
+      this.pop_os();
+    },
+    JOF: (instr: JOF) => {
+      this.PC = this.pop_os() ? this.PC : instr.addr;
+    },
+    GOTO: (instr: GOTO) => {
+      this.PC = instr.addr;
+    },
+    ENTER_SCOPE: (instr: ENTER_SCOPE) => {
+      this.RTS.push(this.memory.blockframe.allocate(this.E));
+      const frame_address = this.memory.frame.allocate(instr.num);
+      this.E = this.memory.environment.extend(frame_address, this.E);
+      for (let i = 0; i < instr.num; i++) {
+        // TODO: how to initialise the variables? unassigned?
+        // this currently initialises all variables to the address of 0, which is False
+        this.memory.heap.set_child(frame_address, i, 0);
+      }
+    },
+    EXIT_SCOPE: (instr: EXIT_SCOPE) => {
+      const scope = this.RTS.pop();
+      if (scope === undefined)
+        throw new Error(`Tried to exit scope when RTS is empty`);
+      this.E = this.memory.blockframe.get_environment(scope);
+    },
+    LD: (instr: LD) => {
+      const val = this.memory.environment.get_value(this.E, instr.pos);
+      this.OS.push(val);
+    },
+    ASSIGN: (instr: ASSIGN) => {
+      this.memory.environment.set_value(this.E, instr.pos, peek(this.OS));
+    },
+    LDF: (instr: LDF) => {
+      const closure_address = this.memory.closure.allocate(
+        instr.params.length,
+        instr.addr,
+        this.E,
+      );
+      this.OS.push(closure_address);
+    },
+    CALL: (instr: CALL) => {
+      const arity = instr.arity;
+      let fun = peek(this.OS, arity);
+      const tag = this.memory.heap.get_tag(fun);
+
+      if (tag === Tag.Builtin) {
+        return this.apply_builtin(this.memory.builtin.get_id(fun));
+      }
+
+      if (tag === Tag.Closure) {
+        const frame_address = this.memory.frame.allocate(arity);
+        for (let i = arity - 1; i >= 0; i--) {
+          this.memory.heap.set_child(frame_address, i, this.OS.pop());
+        }
+        this.OS.pop(); // pop fun
+        this.RTS.push(this.memory.callframe.allocate(this.E, this.PC));
+        this.E = this.memory.environment.extend(
+          frame_address,
+          this.memory.closure.get_environment(fun),
+        );
+        this.PC = this.memory.closure.get_pc(fun);
+        return;
+      }
+
+      throw new Error(`Tried to CALL on a non-function type: tag ${tag}`);
+    },
+    RESET: (instr: RESET) => {
+      this.PC--;
+      const top_frame = this.RTS.pop();
+      if (top_frame === undefined) {
+        throw new Error(`Tried to RESET where RTS is empty`);
+      }
+      if (this.memory.heap.get_tag(top_frame) === Tag.Callframe)
+        this.PC = this.memory.callframe.get_pc(top_frame);
+      this.E = this.memory.callframe.get_environment(top_frame);
+    },
+    DONE: (instr: DONE) => {},
+  };
 }

--- a/go-slang/src/vm/utils.ts
+++ b/go-slang/src/vm/utils.ts
@@ -1,0 +1,36 @@
+import { is_number, is_string, is_boolean } from "../utils";
+import { Token } from "../types/ast";
+
+const binop_microcode: any = {
+  "+": (x: any, y: any) => {
+    if (!(is_number(x) && is_number(y)) && !(is_string(x) && is_string(y)))
+      throw new Error(`Expects two numbers or strings, got: ${x}, ${y}`);
+    return x + y;
+  },
+  "-": (x: number, y: number) => x - y,
+  "*": (x: number, y: number) => x * y,
+  "/": (x: number, y: number) => x / y,
+  "%": (x: number, y: number) => x % y,
+  "<": (x: number, y: number) => x < y,
+  "<=": (x: number, y: number) => x <= y,
+  ">=": (x: number, y: number) => x >= y,
+  ">": (x: number, y: number) => x > y,
+  "==": (x: number, y: number) => x === y,
+  "!=": (x: number, y: number) => x !== y,
+};
+
+export const apply_binop = (op: Token, v2: any, v1: any) =>
+  binop_microcode[op](v1, v2);
+
+const unop_microcode: any = {
+  "-": (x: number) => {
+    if (!is_number(x)) throw new Error(`- expects a number, got: ${x}`);
+    return -x;
+  },
+  "!": (x: boolean) => {
+    if (!is_boolean(x)) throw new Error(`! expects a boolean, got: ${x}`);
+    return !x;
+  },
+};
+
+export const apply_unop = (op: Token, v: any) => unop_microcode[op](v);


### PR DESCRIPTION
Changes

- Extract utility functions from `index.ts` to `utils.ts` (in both compiler and VM)
- Reorder functions within Compiler and VM classes to follow the following order: instance variables, constructor, main driver function (e.g. run or compile), helper functions, microcode
   - microcode is preferred at the end of the file since it is very long, and we do not want functions hiding at the bottom
- Avoid having to list out all the imported types in the import statement by using namespace (see commit 5d778aaa150ce8f73255f9c9efa2c523002d2f31). Not sure if this is better, can revert if not in agreement