### PR TITLE
Implement thread manager class

### DIFF
--- a/go-slang/src/utils.ts
+++ b/go-slang/src/utils.ts
@@ -1,5 +1,3 @@
-import { RuntimeError } from "./errors";
-
 export const is_number = (val: any) => typeof val === "number";
 
 export const is_string = (val: any) => typeof val === "string";

--- a/go-slang/src/vm/index.ts
+++ b/go-slang/src/vm/index.ts
@@ -228,7 +228,7 @@ export class GolangVM {
       this.ctx.program_counter--;
       const top_frame = this.ctx.runtime_stack.pop();
       if (top_frame === undefined) {
-        this.ctx = this.thread_manager.context_switch(this.ctx);
+        this.ctx = this.thread_manager.restore_context() ?? this.ctx;
         return;
       }
 

--- a/go-slang/src/vm/index.ts
+++ b/go-slang/src/vm/index.ts
@@ -12,7 +12,7 @@ import { RuntimeError } from "../errors";
 import { ThreadManager } from "./thread_manager";
 
 export class GolangVM {
-  private context: Context;
+  private ctx: Context;
   private memory: Memory;
   private builtin_array: Array<BuiltinFunction>;
   private thread_manager: ThreadManager;
@@ -20,7 +20,7 @@ export class GolangVM {
   constructor(builtin_mapping: Record<string, BuiltinFunction>) {
     this.memory = new Memory(10000000);
     this.builtin_array = [this.Sleep, ...Object.values(builtin_mapping)];
-    this.context = new Context(0, this.initialise_environment());
+    this.ctx = new Context(0, this.initialise_environment());
     this.thread_manager = new ThreadManager();
   }
 
@@ -40,18 +40,18 @@ export class GolangVM {
   }
 
   run(instrs: VM.Instruction[]) {
-    while (!(instrs[this.context.program_counter]._type === "DONE")) {
+    while (!(instrs[this.ctx.program_counter]._type === "DONE")) {
       if (this.is_sleeping()) {
-        this.context = this.thread_manager.context_switch(this.context);
+        this.ctx = this.thread_manager.context_switch(this.ctx);
         continue;
       }
 
-      const instr = instrs[this.context.program_counter++];
+      const instr = instrs[this.ctx.program_counter++];
       if (this.microcode[instr._type] === undefined)
         throw new RuntimeError(`${instr._type} not supported`);
       this.microcode[instr._type](instr);
 
-      this.context = this.thread_manager.update_scheduler(this.context);
+      this.ctx = this.thread_manager.update_scheduler(this.ctx);
     }
     return this.pop_os();
   }
@@ -59,12 +59,12 @@ export class GolangVM {
   private Sleep: BuiltinFunction = {
     arity: 1,
     apply: (duration: number) => {
-      this.context.sleep_until = new Date(Date.now() + duration);
+      this.ctx.sleep_until = new Date(Date.now() + duration);
     },
   };
 
   private is_sleeping(): boolean {
-    return new Date() < this.context.sleep_until;
+    return new Date() < this.ctx.sleep_until;
   }
 
   private create_function_context(
@@ -74,9 +74,9 @@ export class GolangVM {
   ) {
     const frame_address = this.memory.frame.allocate(arity);
     for (let i = arity - 1; i >= 0; i--) {
-      this.memory.heap.set_child(frame_address, i, this.context.operand_stack.pop());
+      this.memory.heap.set_child(frame_address, i, this.ctx.operand_stack.pop());
     }
-    this.context.operand_stack.pop(); // pop fun
+    this.ctx.operand_stack.pop(); // pop fun
 
     const context = new Context(
       this.memory.closure.get_pc(fun),
@@ -87,16 +87,16 @@ export class GolangVM {
     );
 
     if (extend_current) {
-      context.operand_stack = this.context.operand_stack;
-      context.runtime_stack = this.context.runtime_stack;
-      context.sleep_until = this.context.sleep_until;
+      context.operand_stack = this.ctx.operand_stack;
+      context.runtime_stack = this.ctx.runtime_stack;
+      context.sleep_until = this.ctx.sleep_until;
     }
 
     return context;
   }
 
   private pop_os() {
-    const address = this.context.operand_stack.pop();
+    const address = this.ctx.operand_stack.pop();
     if (address === undefined) {
       return undefined;
       // TODO: throw error? sign that there is an unecessary pop
@@ -106,7 +106,7 @@ export class GolangVM {
   }
 
   private push_os(value: any) {
-    this.context.operand_stack.push(this.memory.js_value_to_address(value));
+    this.ctx.operand_stack.push(this.memory.js_value_to_address(value));
   }
 
   private apply_builtin(id: number) {
@@ -133,21 +133,21 @@ export class GolangVM {
       this.pop_os();
     },
     JOF: (instr: VM.JOF) => {
-      this.context.program_counter = this.pop_os()
-        ? this.context.program_counter
+      this.ctx.program_counter = this.pop_os()
+        ? this.ctx.program_counter
         : instr.addr;
     },
     GOTO: (instr: VM.GOTO) => {
-      this.context.program_counter = instr.addr;
+      this.ctx.program_counter = instr.addr;
     },
     ENTER_SCOPE: (instr: VM.ENTER_SCOPE) => {
-      this.context.runtime_stack.push(
-        this.memory.blockframe.allocate(this.context.environment),
+      this.ctx.runtime_stack.push(
+        this.memory.blockframe.allocate(this.ctx.environment),
       );
       const frame_address = this.memory.frame.allocate(instr.num);
-      this.context.environment = this.memory.environment.extend(
+      this.ctx.environment = this.memory.environment.extend(
         frame_address,
-        this.context.environment,
+        this.ctx.environment,
       );
       for (let i = 0; i < instr.num; i++) {
         // TODO: how to initialise the variables? unassigned?
@@ -156,36 +156,36 @@ export class GolangVM {
       }
     },
     EXIT_SCOPE: (instr: VM.EXIT_SCOPE) => {
-      const scope = this.context.runtime_stack.pop();
+      const scope = this.ctx.runtime_stack.pop();
       if (scope === undefined)
         throw new RuntimeError(`Tried to exit scope when RTS is empty`);
-      this.context.environment = this.memory.blockframe.get_environment(scope);
+      this.ctx.environment = this.memory.blockframe.get_environment(scope);
     },
     LD: (instr: VM.LD) => {
       const val = this.memory.environment.get_value(
-        this.context.environment,
+        this.ctx.environment,
         instr.pos,
       );
-      this.context.operand_stack.push(val);
+      this.ctx.operand_stack.push(val);
     },
     ASSIGN: (instr: VM.ASSIGN) => {
       this.memory.environment.set_value(
-        this.context.environment,
+        this.ctx.environment,
         instr.pos,
-        peek(this.context.operand_stack),
+        peek(this.ctx.operand_stack),
       );
     },
     LDF: (instr: VM.LDF) => {
       const closure_address = this.memory.closure.allocate(
         instr.params.length,
         instr.addr,
-        this.context.environment,
+        this.ctx.environment,
       );
-      this.context.operand_stack.push(closure_address);
+      this.ctx.operand_stack.push(closure_address);
     },
     CALL: (instr: VM.CALL) => {
       const arity = instr.arity;
-      const fun = peek(this.context.operand_stack, arity);
+      const fun = peek(this.ctx.operand_stack, arity);
       const tag = this.memory.heap.get_tag(fun);
 
       if (tag === Tag.Builtin) {
@@ -193,13 +193,13 @@ export class GolangVM {
       }
 
       if (tag === Tag.Closure) {
-        this.context.runtime_stack.push(
+        this.ctx.runtime_stack.push(
           this.memory.callframe.allocate(
-            this.context.environment,
-            this.context.program_counter,
+            this.ctx.environment,
+            this.ctx.program_counter,
           ),
         );
-        this.context = this.create_function_context(fun, arity, true);
+        this.ctx = this.create_function_context(fun, arity, true);
         return;
       }
 
@@ -207,7 +207,7 @@ export class GolangVM {
     },
     THREAD_CALL: (instr: VM.THREAD_CALL) => {
       const arity = instr.arity;
-      const fun = peek(this.context.operand_stack, arity);
+      const fun = peek(this.ctx.operand_stack, arity);
       const tag = this.memory.heap.get_tag(fun);
 
       if (tag === Tag.Builtin) {
@@ -225,17 +225,16 @@ export class GolangVM {
       throw new RuntimeError(`invalid operation: cannot call non-function`);
     },
     RESET: (instr: VM.RESET) => {
-      this.context.program_counter--;
-      const top_frame = this.context.runtime_stack.pop();
+      this.ctx.program_counter--;
+      const top_frame = this.ctx.runtime_stack.pop();
       if (top_frame === undefined) {
-        this.context = this.thread_manager.context_switch(this.context);
+        this.ctx = this.thread_manager.context_switch(this.ctx);
         return;
       }
 
       if (this.memory.heap.get_tag(top_frame) === Tag.Callframe)
-        this.context.program_counter = this.memory.callframe.get_pc(top_frame);
-      this.context.environment =
-        this.memory.callframe.get_environment(top_frame);
+        this.ctx.program_counter = this.memory.callframe.get_pc(top_frame);
+      this.ctx.environment = this.memory.callframe.get_environment(top_frame);
     },
     DONE: (instr: VM.DONE) => {},
   };

--- a/go-slang/src/vm/memory.ts
+++ b/go-slang/src/vm/memory.ts
@@ -1,5 +1,6 @@
 import { Heap } from "./heap";
 import { Tag } from "./tag";
+import { RuntimeError } from "../errors";
 import { is_string, is_number } from "../utils";
 
 export class Memory {
@@ -51,7 +52,7 @@ export class Memory {
     } else if (is_string(value)) {
       return this.string.allocate(value);
     }
-    throw new Error(`Could not convert JS value ${value} to address`);
+    throw new RuntimeError(`Could not convert JS value ${value} to address`);
   }
 
   number = {
@@ -73,7 +74,8 @@ export class Memory {
     },
     get_string: (address: number): string => {
       const string_val = this.string_pool.get(address);
-      if (string_val === undefined) throw new Error("String value not found");
+      if (string_val === undefined)
+        throw new RuntimeError("String value not found");
       return string_val;
     },
   };

--- a/go-slang/src/vm/thread_manager.ts
+++ b/go-slang/src/vm/thread_manager.ts
@@ -1,0 +1,64 @@
+import { Context } from "./thread_context";
+
+const INSTRS_PER_THREAD = 10;
+
+/**
+ * Represents a manager for handling threads and context switching.
+ */
+export class ThreadManager {
+  private thread_queue: Array<Context>;
+  private thread_instr_count: number;
+
+  constructor() {
+    this.thread_queue = [];
+    this.thread_instr_count = 0;
+  }
+
+  /**
+   * Updates the scheduler based on the current context.
+   */
+  public update_scheduler(curr_context: Context): void {
+    this.thread_instr_count++;
+    if (this.thread_instr_count >= INSTRS_PER_THREAD) {
+      this.thread_instr_count = 0;
+      this.context_switch(curr_context);
+    }
+  }
+
+  /**
+   * Switches context from the current to the next context.
+   */
+  public context_switch(curr_context: Context): void {
+    this.add_context_to_queue(curr_context);
+    this.restore_vm_context(curr_context);
+  }
+
+  /**
+   * Saves and adds the current context to the thread queue.
+   */
+  public add_context_to_queue(curr_context: Context): void {
+    this.thread_queue.push(
+      new Context(
+        curr_context.program_counter,
+        curr_context.environment,
+        curr_context.operand_stack,
+        curr_context.runtime_stack,
+        curr_context.sleep_until,
+      ),
+    );
+  }
+
+  /**
+   * Restores the virtual machine context with the next context from the thread queue.
+   * This is done by mutating vm's context object.
+   */
+  private restore_vm_context(curr_context: Context): void {
+    const next_context = this.thread_queue.shift();
+    if (!next_context) return;
+    curr_context.program_counter = next_context.program_counter;
+    curr_context.environment = next_context.environment;
+    curr_context.operand_stack = next_context.operand_stack;
+    curr_context.runtime_stack = next_context.runtime_stack;
+    curr_context.sleep_until = next_context.sleep_until;
+  }
+}

--- a/go-slang/src/vm/thread_manager.ts
+++ b/go-slang/src/vm/thread_manager.ts
@@ -40,6 +40,13 @@ export class ThreadManager {
   }
 
   /**
+   * Gets context of the next thread from the queue.
+   */
+  public restore_context(): Context | undefined {
+    return this.thread_queue.shift()
+  }
+
+  /**
    * Saves and adds the current context to the thread queue.
    */
   public add_context_to_queue(curr_ctx: Context): void {

--- a/go-slang/src/vm/thread_manager.ts
+++ b/go-slang/src/vm/thread_manager.ts
@@ -17,38 +17,39 @@ export class ThreadManager {
   /**
    * Updates the scheduler based on the current context.
    */
-  public update_scheduler(curr_context: Context): Context {
+  public update_scheduler(curr_ctx: Context): Context {
     this.thread_instr_count++;
     if (this.thread_instr_count >= INSTRS_PER_THREAD) {
       this.thread_instr_count = 0;
-      return this.context_switch(curr_context);
+      return this.context_switch(curr_ctx);
     }
-    return curr_context;
+    return curr_ctx;
   }
 
   /**
-   * Switches context from the current to the next context.
+   * Switches context from the current to
+   * the next context from the thread queue.
    */
-  public context_switch(curr_context: Context): Context {
+  public context_switch(curr_ctx: Context): Context {
     if (this.thread_queue.length > 0) {
-      this.add_context_to_queue(curr_context);
-      const next_context = this.thread_queue.shift();
-      if (next_context) return next_context;
+      this.add_context_to_queue(curr_ctx);
+      const next_ctx = this.thread_queue.shift();
+      if (next_ctx) return next_ctx;
     }
-    return curr_context
+    return curr_ctx;
   }
 
   /**
    * Saves and adds the current context to the thread queue.
    */
-  public add_context_to_queue(curr_context: Context): void {
+  public add_context_to_queue(curr_ctx: Context): void {
     this.thread_queue.push(
       new Context(
-        curr_context.program_counter,
-        curr_context.environment,
-        curr_context.operand_stack,
-        curr_context.runtime_stack,
-        curr_context.sleep_until,
+        curr_ctx.program_counter,
+        curr_ctx.environment,
+        curr_ctx.operand_stack,
+        curr_ctx.runtime_stack,
+        curr_ctx.sleep_until,
       ),
     );
   }

--- a/go-slang/src/vm/thread_manager.ts
+++ b/go-slang/src/vm/thread_manager.ts
@@ -17,22 +17,25 @@ export class ThreadManager {
   /**
    * Updates the scheduler based on the current context.
    */
-  public update_scheduler(curr_context: Context): void {
+  public update_scheduler(curr_context: Context): Context {
     this.thread_instr_count++;
     if (this.thread_instr_count >= INSTRS_PER_THREAD) {
       this.thread_instr_count = 0;
-      this.context_switch(curr_context);
+      return this.context_switch(curr_context);
     }
+    return curr_context;
   }
 
   /**
    * Switches context from the current to the next context.
    */
-  public context_switch(curr_context: Context): void {
+  public context_switch(curr_context: Context): Context {
     if (this.thread_queue.length > 0) {
       this.add_context_to_queue(curr_context);
-      this.restore_vm_context(curr_context);
+      const next_context = this.thread_queue.shift();
+      if (next_context) return next_context;
     }
+    return curr_context
   }
 
   /**
@@ -48,19 +51,5 @@ export class ThreadManager {
         curr_context.sleep_until,
       ),
     );
-  }
-
-  /**
-   * Restores the virtual machine context with the next context
-   * from the thread queue by mutating vm's context object.
-   */
-  private restore_vm_context(curr_context: Context): void {
-    const next_context = this.thread_queue.shift();
-    if (!next_context) return;
-    curr_context.program_counter = next_context.program_counter;
-    curr_context.environment = next_context.environment;
-    curr_context.operand_stack = next_context.operand_stack;
-    curr_context.runtime_stack = next_context.runtime_stack;
-    curr_context.sleep_until = next_context.sleep_until;
   }
 }

--- a/go-slang/src/vm/thread_manager.ts
+++ b/go-slang/src/vm/thread_manager.ts
@@ -29,8 +29,10 @@ export class ThreadManager {
    * Switches context from the current to the next context.
    */
   public context_switch(curr_context: Context): void {
-    this.add_context_to_queue(curr_context);
-    this.restore_vm_context(curr_context);
+    if (this.thread_queue.length > 0) {
+      this.add_context_to_queue(curr_context);
+      this.restore_vm_context(curr_context);
+    }
   }
 
   /**
@@ -49,8 +51,8 @@ export class ThreadManager {
   }
 
   /**
-   * Restores the virtual machine context with the next context from the thread queue.
-   * This is done by mutating vm's context object.
+   * Restores the virtual machine context with the next context
+   * from the thread queue by mutating vm's context object.
    */
   private restore_vm_context(curr_context: Context): void {
     const next_context = this.thread_queue.shift();


### PR DESCRIPTION
Changes:
- Add a new thread manager class to handle concurrency related tasks to adhere to SRP
- The various states in VM are removed and encapsulated by a Context object instead
- VM's context object is updated by reassigning `this.context` from thread manager's context switch method