### PR TITLE
Implement CLI configs for memory and debug_os

### DIFF
--- a/go-slang/examples/run.ts
+++ b/go-slang/examples/run.ts
@@ -5,8 +5,9 @@
 
 import { GolangRunner } from "../src";
 import { BuiltinFunction } from "../src/types";
+import { Config } from "../src/vm/config";
 
-const config: Record<string, string> = process.argv
+const args: Record<string, string> = process.argv
   .slice(2)
   .reduce((acc, arg) => {
     const match = arg.match(/^--([^=]+)=(.*)$/);
@@ -19,7 +20,7 @@ const external_builtins: Record<string, BuiltinFunction> = {
     apply: (v: any) => console.log(v),
   },
 };
-const runner = new GolangRunner(external_builtins, config);
+const runner = new GolangRunner(external_builtins, Config.from_args(args));
 
 process.stdin.setEncoding("utf8");
 let program = "";

--- a/go-slang/examples/run.ts
+++ b/go-slang/examples/run.ts
@@ -1,8 +1,17 @@
 // can be run using
-// npx ts-node run.ts < xxx.go
+// npx ts-node run.ts < xxx.go > xxx.out
+// npx ts-node run.ts < xxx.go --memory=1000
+// npx ts-node run.ts < xxx.go --debug_os=true
 
 import { GolangRunner } from "../src";
 import { BuiltinFunction } from "../src/types";
+
+const config: Record<string, string> = process.argv
+  .slice(2)
+  .reduce((acc, arg) => {
+    const match = arg.match(/^--([^=]+)=(.*)$/);
+    return match ? { ...acc, [match[1]]: match[2] } : acc;
+  }, {});
 
 const external_builtins: Record<string, BuiltinFunction> = {
   Println: {
@@ -10,7 +19,7 @@ const external_builtins: Record<string, BuiltinFunction> = {
     apply: (v: any) => console.log(v),
   },
 };
-const runner = new GolangRunner(external_builtins);
+const runner = new GolangRunner(external_builtins, config);
 
 process.stdin.setEncoding("utf8");
 let program = "";

--- a/go-slang/src/index.ts
+++ b/go-slang/src/index.ts
@@ -3,6 +3,7 @@ import { GolangParser } from "./parser";
 import { GolangTypechecker } from "./typechecker";
 import { BuiltinFunction, RunnerResult } from "./types";
 import { GolangVM } from "./vm";
+import { Config } from "./vm/config";
 
 // Facade class that contains parser, compiler and vm / main entry point
 export class GolangRunner {
@@ -13,7 +14,7 @@ export class GolangRunner {
 
   constructor(
     external_builtins: Record<string, BuiltinFunction> = {},
-    config: Record<string, string> = {},
+    config: Config = new Config(),
   ) {
     this.parser = new GolangParser();
     this.typechecker = new GolangTypechecker(external_builtins);

--- a/go-slang/src/index.ts
+++ b/go-slang/src/index.ts
@@ -11,11 +11,14 @@ export class GolangRunner {
   private compiler: GolangCompiler;
   private vm: GolangVM;
 
-  constructor(external_builtins: Record<string, BuiltinFunction> = {}) {
+  constructor(
+    external_builtins: Record<string, BuiltinFunction> = {},
+    config: Record<string, string> = {},
+  ) {
     this.parser = new GolangParser();
     this.typechecker = new GolangTypechecker(external_builtins);
     this.compiler = new GolangCompiler(external_builtins);
-    this.vm = new GolangVM(external_builtins);
+    this.vm = new GolangVM(external_builtins, config);
   }
 
   async execute(program: string): Promise<RunnerResult> {

--- a/go-slang/src/vm/config.ts
+++ b/go-slang/src/vm/config.ts
@@ -1,0 +1,13 @@
+export class Config {
+  constructor(
+    public readonly memory: number = 1000000,
+    public readonly debug_os: boolean = false,
+  ) {}
+
+  static from_args(args: Record<string, string>): Config {
+    return new Config(
+      parseInt(args.memory) || 10000000,
+      args.debug_os === "true",
+    );
+  }
+}


### PR DESCRIPTION
Example commands

```sh
npx ts-node run.ts < xxx.go > xxx.out
npx ts-node run.ts < xxx.go --memory=1000
npx ts-node run.ts < xxx.go --debug_os=true
```
